### PR TITLE
ローカルではFirebase Emulatorに接続するように修正

### DIFF
--- a/src/firebase_config.ts
+++ b/src/firebase_config.ts
@@ -29,9 +29,9 @@ export const getIdToken = async () => {
 };
 
 // 開発中はエミュレータにアクセス
-if(Config.isDev) {
+if (Config.isDev) {
   const emuConf = Config.emulator;
-  if(emuConf.host){
+  if (emuConf.host) {
     connectAuthEmulator(_auth, `http://${emuConf.host}:${emuConf.ports.authentication}`);
     connectDatabaseEmulator(_db, emuConf.host, emuConf.ports.database);
     connectFirestoreEmulator(_store, emuConf.host, emuConf.ports.firestore);

--- a/src/firebase_config.ts
+++ b/src/firebase_config.ts
@@ -2,10 +2,10 @@ import _firebase from "firebase/compat/app";
 import "firebase/compat/auth";
 
 import Config from "config";
-import { getAuth as fb_getAuth } from "firebase/auth";
-import { getDatabase as fb_getDatabase } from "firebase/database";
-import { getFirestore as fb_getFirestore } from "firebase/firestore";
-import { getStorage as fb_getStorage } from "firebase/storage";
+import { connectAuthEmulator, getAuth as fb_getAuth } from "firebase/auth";
+import { connectDatabaseEmulator, getDatabase as fb_getDatabase } from "firebase/database";
+import { connectFirestoreEmulator, getFirestore as fb_getFirestore } from "firebase/firestore";
+import { connectStorageEmulator, getStorage as fb_getStorage } from "firebase/storage";
 
 // ---- firebaseの初期化と基本機能のエクスポート ---- //
 export const firebaseApp = _firebase.initializeApp(Config.firebase);
@@ -18,10 +18,10 @@ const _storage = fb_getStorage();
 
 // 取得関数をエクスポート
 export const firebase = _firebase;
-export const getAuth = () => _auth;
-export const getDatabase = () => _db;
-export const getFirestore = () => _store;
-export const getStorage = () => _storage;
+export const getAuth = () => fb_getAuth();
+export const getDatabase = () => fb_getDatabase();
+export const getFirestore = () => fb_getFirestore();
+export const getStorage = () => fb_getStorage();
 
 // ---- その他firebase関連の便利関数群 ---- //
 export const getIdToken = async () => {
@@ -29,12 +29,12 @@ export const getIdToken = async () => {
 };
 
 // 開発中はエミュレータにアクセス
-// if(Config.isDev) {
-//   const emuConf = Config.emulator;
-//   if(emuConf.host){
-//     connectAuthEmulator(_auth, `http://${emuConf.host}:${emuConf.ports}`);
-//     connectDatabaseEmulator(_db, emuConf.host, emuConf.ports.database);
-//     connectFirestoreEmulator(_store, emuConf.host, emuConf.ports.firestore);
-//     connectStorageEmulator(_storage, emuConf.host, emuConf.ports.firestore);
-//   }
-// }
+if(Config.isDev) {
+  const emuConf = Config.emulator;
+  if(emuConf.host){
+    connectAuthEmulator(_auth, `http://${emuConf.host}:${emuConf.ports.authentication}`);
+    connectDatabaseEmulator(_db, emuConf.host, emuConf.ports.database);
+    connectFirestoreEmulator(_store, emuConf.host, emuConf.ports.firestore);
+    connectStorageEmulator(_storage, emuConf.host, emuConf.ports.storage);
+  }
+}


### PR DESCRIPTION
# やったこと
- ローカル開発環境ではFirebase Emulator Suiteに接続するように修正しました
  - これで本番環境に影響することなく開発することが出来ます．
# やってないこと
- データベースの初期値を設定していない
  - Emulatorを再起動するとデータが消えるので毎回データを設定しなければいけない
  - これはfirebaseリポジトリでその内設定