### PR TITLE
[DESIGN] IconTextを実装

### DIFF
--- a/src/components/IconText/IconText.stories.tsx
+++ b/src/components/IconText/IconText.stories.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { IconText } from "./IconText";
+import { Home } from "components/icons";
+import { BrowserRouter } from "react-router-dom";
+
+export default {
+  title: "components/IconText",
+  component: IconText,
+} as ComponentMeta<typeof IconText>;
+
+const Template: ComponentStory<typeof IconText> = (args) => (
+  // Linkタグを使用しているのでBrowserRouterで囲う
+  <BrowserRouter>
+    <IconText {...args} />
+  </BrowserRouter>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  to: "#",
+  Icon: Home,
+  text: "ホーム",
+  status: "Default",
+};
+
+export const Active = Template.bind({});
+Active.args = {
+  ...Default.args,
+  status: "Active",
+};

--- a/src/components/IconText/IconText.tsx
+++ b/src/components/IconText/IconText.tsx
@@ -1,0 +1,19 @@
+import React, { ComponentType } from "react";
+import { IconStyleProps, IconTextStyle, IconTextStyleProps } from "./IconTextStyle";
+import { IconProps } from "components/icons/components/IconPrototype/IconPrototype";
+import { To } from "react-router-dom";
+
+type Props = IconTextStyleProps & {
+  to: To;
+  Icon: ComponentType<IconProps>;
+  text: string;
+};
+
+export const IconText: React.FC<Props> = ({ to, Icon, text, ...styleProps }) => {
+  return (
+    <IconTextStyle to={to} {...styleProps}>
+      <Icon {...IconStyleProps({ ...styleProps })} />
+      <span className="icontext_label">{text}</span>
+    </IconTextStyle>
+  );
+};

--- a/src/components/IconText/IconTextStyle.tsx
+++ b/src/components/IconText/IconTextStyle.tsx
@@ -1,0 +1,58 @@
+import styled, { css, useTheme } from "styled-components";
+import { IconProps } from "components/icons/components/IconPrototype/IconPrototype";
+import { FlexGap } from "styles/FlexGap/FlexGap";
+import { Link } from "react-router-dom";
+
+export type IconTextStyleProps = {
+  status?: "Default" | "Active";
+};
+
+const defaultStyle = css`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 12px 12px 12px 24px;
+  ${FlexGap({ gap: "24px", direction: "row" })}
+
+  width: 272px;
+  text-decoration: none;
+
+  .icontext_label {
+    color: ${({ theme }) => theme.global.font};
+  }
+`;
+
+const hoverStyle = css`
+  background-color: ${({ theme }) => theme.iconText.hover};
+`;
+
+const activeStyle = css`
+  pointer-events: none;
+
+  .icontext_label {
+    color: ${({ theme }) => theme.iconText.active.font};
+  }
+`;
+
+export const IconTextStyle = styled(Link)<IconTextStyleProps>`
+  ${defaultStyle}
+
+  :hover {
+    ${({ status }) => status === "Default" && hoverStyle}
+  }
+  ${({ status }) => status === "Active" && activeStyle}
+`;
+
+IconTextStyle.defaultProps = {
+  status: "Default",
+};
+
+export const IconStyleProps: (props: IconTextStyleProps) => IconProps = ({ status }) => {
+  const theme = useTheme();
+
+  return {
+    fill: status == "Active" ? theme.iconText.active.font : theme.global.font,
+    size: "24px",
+  };
+};

--- a/src/styles/Themes/DefaultTheme.ts
+++ b/src/styles/Themes/DefaultTheme.ts
@@ -20,6 +20,7 @@ import {
   BLUE_GRAY_85,
   GRAY_65,
   GRAY_55,
+  ORANGE_30,
 } from "styles/colors";
 
 export const DefaultTheme = {
@@ -126,6 +127,12 @@ export const DefaultTheme = {
     frame: {
       base: GRAY_100,
       border: BLUE_GRAY_60,
+    },
+  },
+  iconText: {
+    hover: GRAY_20,
+    active: {
+      font: ORANGE_30,
     },
   },
 };


### PR DESCRIPTION
## チケットリンク
- #28 

## やったこと
- IconTextを実装しました

## やらなかったこと
- UserMenuのNavLinkには対応していません。UserMenu側でDOMを変更してください。

## レビュー項目
- [ ] IconTextがデザイン通りに実装されている
- [ ] ホバーすると背景色が変わる
- [ ] activeにするとクリックできなくなる

## 備考
- チケットには書いてなかったが、基本的にリンク付きで使用するため、トップコンポーネントを`Link`にしました
  - これに伴い、コンポーネントプロパティに`to(URLリンクを指定するプロパティ)`を追加しました
