### PR TITLE
コルボポイントを計算するロジックを実装

### DIFF
--- a/src/hooks/CollvoPoint/useCollvoPoint.ts
+++ b/src/hooks/CollvoPoint/useCollvoPoint.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { COLLVO_POINT } from "styles/constants/constants";
+import { loadAllActionsAsync, PresenterAction } from "services/RealtimeGrandPrix/StatsGrandPrix";
+import { RootState } from "store";
+import { PresenterCollvoPoint } from "./useCollvoPoints";
+
+export type IndividualPresenterCollvoPoint = Pick<PresenterCollvoPoint, "reactionPoint" | "boostPoint">;
+
+export type IResponse = {
+  calculate: (presenterId: string) => IndividualPresenterCollvoPoint;
+};
+
+export const calculatePresenterCollvoPoint = ({
+  plainReactions,
+  messageReactions,
+  boostActions,
+}: PresenterAction): IndividualPresenterCollvoPoint => {
+  const reactionPoint =
+    plainReactions.sortedKey.length * COLLVO_POINT.PLAIN_REACTION +
+    messageReactions.sortedKey.length * COLLVO_POINT.MESSAGE_REACTION;
+
+  const boostPoints = Object.values(boostActions.data).map((boostAction) => {
+    const boostStart = boostAction.sendAt;
+    const boostEnd = new Date(boostStart.getTime() + COLLVO_POINT.BOOST_ACTION.DURATION * 1000);
+
+    const plainReaction =
+      Object.values(plainReactions.data).filter(
+        (plainReaction) =>
+          boostStart.getTime() <= plainReaction.sendAt.getTime() && plainReaction.sendAt.getTime() <= boostEnd.getTime()
+      ).length *
+      COLLVO_POINT.PLAIN_REACTION *
+      COLLVO_POINT.BOOST_ACTION.CP_MAG;
+
+    const messageReaction =
+      Object.values(messageReactions.data).filter(
+        (messageReaction) =>
+          boostStart.getTime() <= messageReaction.sendAt.getTime() &&
+          messageReaction.sendAt.getTime() <= boostEnd.getTime()
+      ).length *
+      COLLVO_POINT.MESSAGE_REACTION *
+      COLLVO_POINT.BOOST_ACTION.CP_MAG;
+
+    return plainReaction + messageReaction;
+  });
+
+  const boostPoint = boostPoints.reduce((sum, value) => {
+    return sum + value;
+  }, 0);
+
+  return {
+    reactionPoint,
+    boostPoint,
+  };
+};
+
+/**
+ * 指定したグランプリID、プレゼンターID（ユーザID）のコルボポイントを計算する
+ */
+export const useCollvoPoint = (grandPrixId: string): IResponse => {
+  const statsGrandPrix = useSelector((state: RootState) => state.statsGrandPrix);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(loadAllActionsAsync(grandPrixId));
+  }, [grandPrixId]);
+
+  const calculate = useCallback(
+    (presenterId: string) => {
+      if (!(grandPrixId in statsGrandPrix) || !(presenterId in statsGrandPrix[grandPrixId]))
+        return {
+          reactionPoint: 0,
+          boostPoint: 0,
+        };
+      return calculatePresenterCollvoPoint(statsGrandPrix[grandPrixId][presenterId]);
+    },
+    [grandPrixId, statsGrandPrix]
+  );
+
+  return {
+    calculate,
+  };
+};

--- a/src/hooks/CollvoPoint/useCollvoPoints.ts
+++ b/src/hooks/CollvoPoint/useCollvoPoints.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useState } from "react";
+import { usePresenters } from "hooks/Presenters/usePresenters";
+import { IndividualPresenterCollvoPoint, useCollvoPoint } from "./useCollvoPoint";
+import { COLLVO_POINT } from "styles/constants/constants";
+import { Dict } from "Types/Utils";
+import { ActionList } from "services/RealtimeGrandPrix/RealtimeGrandPrix";
+
+export type PresenterCollvoPoint = {
+  presenterId: string;
+  reactionPoint: number;
+  boostPoint: number;
+  rank: number;
+  rankPoint: number;
+  totalPoint: number;
+};
+
+export type IResponse = {
+  /**
+   * プレゼンターが所有するコルボポイント
+   */
+  presenterCollvoPoints: ActionList<PresenterCollvoPoint>;
+  reload: () => void;
+};
+
+/**
+ * 指定したグランプリの全プレゼンターのコルボポイントを計算するフック
+ * reload関数を呼ぶと値が更新される
+ */
+export const useCollvoPoints = (grandPrixId: string): IResponse => {
+  const { presenters, setGrandPrixId } = usePresenters();
+  const { calculate } = useCollvoPoint(grandPrixId);
+  const [presenterCollvoPoints, setPresenterCollvoPoints] = useState<ActionList<PresenterCollvoPoint>>({
+    sortedKey: [],
+    data: {},
+  });
+
+  useEffect(() => {
+    setGrandPrixId(grandPrixId);
+  }, [grandPrixId]);
+
+  const reload = useCallback(() => {
+    const presenterIds = Object.keys(presenters);
+    if (!presenters || presenterIds.length == 0) return;
+
+    const flatCPs = presenterIds.reduce<Dict<IndividualPresenterCollvoPoint>>((arr, pId) => {
+      arr[pId] = calculate(pId);
+      return arr;
+    }, {});
+
+    // ランキングを計算
+    const ranking = presenterIds.sort((pId1, pId2) => {
+      const total1 = flatCPs[pId1].reactionPoint + flatCPs[pId1].boostPoint;
+      const total2 = flatCPs[pId2].reactionPoint + flatCPs[pId2].boostPoint;
+      return total1 < total2 ? 1 : total1 > total2 ? -1 : 0;
+    });
+
+    // ランクポイントの振り分け
+    let currentPoint = flatCPs[ranking[0]].reactionPoint + flatCPs[ranking[0]].boostPoint;
+    let currentRank = 0;
+    const rankPoints = [COLLVO_POINT.RANKING.one, COLLVO_POINT.RANKING.two, COLLVO_POINT.RANKING.three];
+    const rankOutPoint = COLLVO_POINT.RANKING.other;
+    const newPresenterCollvoPoints = ranking.reduce<Dict<PresenterCollvoPoint>>((dict, pId, index) => {
+      const totalPointWithoutRank = flatCPs[pId].reactionPoint + flatCPs[pId].boostPoint;
+
+      // 同順位でなければ次のランクに進める
+      if (totalPointWithoutRank !== currentPoint) {
+        currentPoint = totalPointWithoutRank;
+        currentRank = index;
+      }
+
+      const rankPoint = currentRank < rankPoints.length ? rankPoints[currentRank] : rankOutPoint;
+
+      const totalPoint = totalPointWithoutRank + rankPoint;
+
+      dict[pId] = {
+        presenterId: pId,
+        reactionPoint: flatCPs[pId].reactionPoint,
+        boostPoint: flatCPs[pId].boostPoint,
+        rank: currentRank + 1,
+        rankPoint: rankPoint,
+        totalPoint: totalPoint,
+      };
+      return dict;
+    }, {});
+
+    setPresenterCollvoPoints({
+      sortedKey: ranking,
+      data: newPresenterCollvoPoints,
+    });
+  }, [presenters, calculate]);
+
+  return {
+    presenterCollvoPoints,
+    reload,
+  };
+};

--- a/src/pages/Admin/GrandPrixController/GrandPrixController.tsx
+++ b/src/pages/Admin/GrandPrixController/GrandPrixController.tsx
@@ -1,6 +1,6 @@
 import { WithHeaderFooter } from "components/Layout/WithHeaderFooter/WithHeaderFooter";
 import React from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { EditablePresenter } from "./components/EditablePresenter/EditablePresenter";
 import { useGrandPrixControllerState } from "./hooks/useGrandPrixControllerState";
 
@@ -10,6 +10,8 @@ export const GrandPrixController: React.FC<Props> = () => {
   const {
     grandPrixId,
     presenters,
+    presenterCollvoPoints,
+    recalcCPHandler,
     sortedPresenterKeys,
     changePresenterBtns,
     loading,
@@ -54,6 +56,7 @@ export const GrandPrixController: React.FC<Props> = () => {
         </li>
         <li>
           プレゼンター一覧
+          <button onClick={recalcCPHandler}>CPを再計算する</button>
           <ul>
             {sortedPresenterKeys.map((key) => (
               <li key={key}>
@@ -64,15 +67,38 @@ export const GrandPrixController: React.FC<Props> = () => {
                   </button>
                   {changePresenterBtns[key]?.disabled ? "発表中" : undefined}
                 </div>
-                <div>プレゼンター情報</div>
+                <div>プレゼンター情報の編集</div>
                 <EditablePresenter grandPrixId={grandPrixId || ""} presenterId={key} />
+                <div>現在の獲得ポイント</div>
+                <ul>
+                  <li>
+                    リアクションポイント：
+                    {presenterCollvoPoints.data[key]?.reactionPoint}
+                  </li>
+                  <li>
+                    ブーストポイント：
+                    {presenterCollvoPoints.data[key]?.boostPoint}
+                  </li>
+                  <li>
+                    順位：
+                    {presenterCollvoPoints.data[key]?.rank}位
+                  </li>
+                  <li>
+                    順位ポイント：
+                    {presenterCollvoPoints.data[key]?.rankPoint}
+                  </li>
+                  <li>
+                    合計獲得ポイント：
+                    {presenterCollvoPoints.data[key]?.totalPoint}
+                  </li>
+                </ul>
               </li>
             ))}
           </ul>
           <button onClick={resetPresenterBtn.handler}>誰も発表していない状態にする</button>
         </li>
         <li>
-          <Link to={`/live/${useParams()["id"]}`}>ライブ画面</Link>
+          <Link to={`/live/${grandPrixId}`}>ライブ画面</Link>
         </li>
       </ul>
     </WithHeaderFooter>

--- a/src/pages/Admin/GrandPrixController/hooks/useGrandPrixControllerState.ts
+++ b/src/pages/Admin/GrandPrixController/hooks/useGrandPrixControllerState.ts
@@ -1,29 +1,11 @@
-import { PresenterWithUser, usePresenters } from "hooks/Presenters/usePresenters";
+import { useCollvoPoints } from "hooks/CollvoPoint/useCollvoPoints";
+import { usePresenters } from "hooks/Presenters/usePresenters";
 import { useRealtimeGrandPrix } from "hooks/RealtimeGrandPrix/useRealtimeGrandPrix";
 import { useRealtimeGrandPrixSetup } from "hooks/RealtimeGrandPrix/useRealtimeGrandPrixSetup";
 import { useTimer } from "hooks/Timer/useTimer";
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
-import { RTGrandPrix } from "services/RealtimeGrandPrix/RealtimeGrandPrix";
 import { ButtonOpts, Dict } from "Types/Utils";
-
-export type IResponse = {
-  grandPrixId?: string;
-  realtimeGrandPrix?: RTGrandPrix;
-  presenters: Dict<PresenterWithUser>;
-  changePresenterBtns: Dict<ButtonOpts>;
-  sortedPresenterKeys: string[];
-  loading: boolean;
-  isCreated: boolean;
-  enabled: boolean;
-  error?: string;
-  createBtn: ButtonOpts;
-  toggleEnabledBtn: ButtonOpts;
-  resetPresenterBtn: ButtonOpts;
-  startTimer: () => void;
-  stopTimer: () => void;
-  resetTimer: () => void;
-};
 
 export const Status = {
   loading: 0,
@@ -32,7 +14,7 @@ export const Status = {
 } as const;
 export type StatusType = typeof Status[keyof typeof Status];
 
-export const useGrandPrixControllerState = (): IResponse => {
+export const useGrandPrixControllerState = () => {
   useRealtimeGrandPrixSetup();
   const { realtimeGrandPrix, createGrandPrix, enterGrandPrix, updateGrandPrix } = useRealtimeGrandPrix();
   const { presenters, setGrandPrixId } = usePresenters();
@@ -42,11 +24,16 @@ export const useGrandPrixControllerState = (): IResponse => {
   const [createBtnDisabled, setCreateBtnDisabled] = useState(false);
   const [toggleEnabledBtnDisabled, setToggleEnabledBtnDisabled] = useState(false);
   const { id } = useParams();
+  const { presenterCollvoPoints, reload } = useCollvoPoints(id || "");
 
   const sortedPresenterKeys = useMemo(
     () => Object.keys(presenters).sort((a, b) => (presenters[a].index < presenters[b].index ? -1 : 1)),
     [presenters]
   );
+
+  useEffect(() => {
+    reload();
+  }, [presenters]);
 
   useEffect(() => {
     if (id) {
@@ -151,6 +138,8 @@ export const useGrandPrixControllerState = (): IResponse => {
     grandPrixId: id,
     realtimeGrandPrix: realtimeGrandPrix.grandPrix,
     presenters: presenters,
+    presenterCollvoPoints,
+    recalcCPHandler: reload,
     sortedPresenterKeys: sortedPresenterKeys,
     changePresenterBtns: presenterBtns,
     loading: status == Status.loading,

--- a/src/services/RealtimeGrandPrix/StatsGrandPrix.ts
+++ b/src/services/RealtimeGrandPrix/StatsGrandPrix.ts
@@ -1,0 +1,89 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import "firebase_config";
+import { ThunkResult } from "services/Utils/Types";
+import { Dict } from "Types/Utils";
+import { getAllActions } from "./DBOperator/DBOperator";
+import {
+  ActionList,
+  BoostAction,
+  BoostActionOnDB,
+  HotItem,
+  MessageReaction,
+  MessageReactionOnDB,
+  MuteAction,
+  MuteActionOnDB,
+  PlainReaction,
+  PlainReactionOnDB,
+} from "./RealtimeGrandPrix";
+
+// ---- DB上での構造 ---- //
+
+export type PresenterActionsOnDB = {
+  plainReactions?: Dict<PlainReactionOnDB>;
+  messageReactions?: Dict<MessageReactionOnDB>;
+  boostActions?: Dict<BoostActionOnDB>;
+  muteActions?: Dict<MuteActionOnDB>;
+};
+
+export type PresenterAction = {
+  plainReactions: ActionList<HotItem<PlainReaction>>;
+  messageReactions: ActionList<HotItem<MessageReaction>>;
+  boostActions: ActionList<HotItem<BoostAction>>;
+  muteActions: ActionList<HotItem<MuteAction>>;
+};
+
+export type StatsGrandPrix = {
+  [grandPrixId: string]: {
+    [presenterId: string]: PresenterAction;
+  };
+};
+
+export type StatsGrandPrixState = StatsGrandPrix;
+
+// ---- Payloadの定義 ---- //
+type SetActionsPayload = PayloadAction<{
+  grandPrixId: string;
+  actions: Dict<PresenterAction>;
+}>;
+
+const initialState: StatsGrandPrixState = {};
+
+const statsGrandPrixSlice = createSlice({
+  name: "statsGrandPrix",
+  initialState: { ...initialState } as StatsGrandPrixState,
+  reducers: {
+    setActions: (state, action: SetActionsPayload) => {
+      const { grandPrixId, actions } = action.payload;
+      state[grandPrixId] = actions;
+    },
+  },
+});
+
+export const { setActions } = statsGrandPrixSlice.actions;
+
+export default statsGrandPrixSlice.reducer;
+
+export const loadAllActionsAsync = (grandPrixId: string): ThunkResult<void> => {
+  return async (dispatch, getState) => {
+    if (grandPrixId == "") return;
+    if (grandPrixId in getState().statsGrandPrix) return;
+
+    await dispatch(reloadAllActionsAsync(grandPrixId));
+  };
+};
+
+export const reloadAllActionsAsync = (grandPrixId: string): ThunkResult<void> => {
+  return async (dispatch) => {
+    if (grandPrixId == "") return;
+
+    const actions = await getAllActions(grandPrixId);
+    if (actions) {
+      dispatch(
+        setActions({
+          grandPrixId,
+          actions,
+        })
+      );
+    }
+  };
+};

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,6 +3,7 @@ import thunk from "redux-thunk";
 
 import userReducer, { UserState } from "services/User/User";
 import realtimeGrandPrixReducer, { RTGrandPrixState } from "services/RealtimeGrandPrix/RealtimeGrandPrix";
+import statsGrandPrixReducer, { StatsGrandPrixState } from "services/RealtimeGrandPrix/StatsGrandPrix";
 import stampsReducer, { StampsState } from "services/Stamps/Stamps";
 import stampTypesReducer, { StampTypesState } from "services/StampTypes/StampTypes";
 import grandPrixesReducer, { GrandPrixesState } from "services/GrandPrixes/GrandPrixes";
@@ -13,6 +14,7 @@ export type RootState = {
   user: UserState;
   users: UsersState;
   realtimeGrandPrix: RTGrandPrixState;
+  statsGrandPrix: StatsGrandPrixState;
   stamps: StampsState;
   stampTypes: StampTypesState;
   grandPrixes: GrandPrixesState;
@@ -24,6 +26,7 @@ export const store = configureStore({
     user: userReducer,
     users: usersReducer,
     realtimeGrandPrix: realtimeGrandPrixReducer,
+    statsGrandPrix: statsGrandPrixReducer,
     stamps: stampsReducer,
     stampTypes: stampTypesReducer,
     grandPrixes: grandPrixesReducer,

--- a/src/styles/constants/constants.ts
+++ b/src/styles/constants/constants.ts
@@ -15,3 +15,30 @@ export const FONT_SIZE = {
   MEDIUM: "2.0rem",
   STRONG: "2.2rem",
 };
+
+export const COLLVO_POINT = {
+  PLAIN_REACTION: 5,
+  MESSAGE_REACTION: 5,
+  RANKING: {
+    one: 1000,
+    two: 500,
+    three: 300,
+    other: 50,
+  },
+  MUTE_ACTION: {
+    /**
+     * 最大効果時間(秒)
+     */
+    MAX_DURATION: 30,
+  },
+  BOOST_ACTION: {
+    /**
+     * 効果時間(秒)
+     */
+    DURATION: 30,
+    /**
+     * ブーストアクション使用時の獲得コルボポイントの倍率
+     */
+    CP_MAG: 1.5,
+  },
+};


### PR DESCRIPTION
## チケットリンク
- #44 

## やったこと
- コルボポイントを計算するロジックを実装
- statsGrandPrixサービスを実装
  - コルボポイントを計算するのに必要な情報を取得する

## やらなかったこと
- ポイント付与については #45 で実装する

## レビュー項目
- [ ] グランプリ裏メニューぺーじにて、各プレゼンターの獲得ポイントを見ることが出来る

## 備考
- 特に無し
