### PR TITLE
プレゼン進行ボイスの実装

### DIFF
--- a/src/Utils/funcs.ts
+++ b/src/Utils/funcs.ts
@@ -20,3 +20,13 @@ export const max = (a: number, b: number): number => {
 export const dateToTime = (date: Date): string => {
   return date.toISOString().slice(14, 19);
 };
+
+/**
+ * リストの中からランダムに値を選択する
+ * @param array 対象リスト
+ * @returns ランダムに選ばれた要素
+ */
+export const randomChoice = <T>(array: T[]) => {
+  if (array.length === 0) return undefined;
+  return array[Math.floor(Math.random() * array.length)];
+};

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -40,7 +40,7 @@ export const SideMenu: React.FC<Props> = ({ user, ...styleProps }) => {
           <div className="sidemenu_bar" />
           <ul>
             <li>
-              <NavIconText to="/admin" Icon={Cog} text="運営トップ" />
+              <NavIconText to="/admin/" Icon={Cog} text="運営トップ" />
             </li>
           </ul>
         </>

--- a/src/components/SideMenu/components/NavIconText/NavIconText.tsx
+++ b/src/components/SideMenu/components/NavIconText/NavIconText.tsx
@@ -1,18 +1,18 @@
 import React from "react";
-import { IconStyleProps, NavIconTextStyle, NavIconTextStyleProps } from "./NavIconTextStyle";
+import { IconStyleProps, NavIconTextStyle } from "./NavIconTextStyle";
 import { To } from "react-router-dom";
 import { Icon } from "Types/Utils";
 
-type Props = NavIconTextStyleProps & {
+type Props = {
   to: To;
   Icon: Icon;
   text: string;
 };
 
-export const NavIconText: React.FC<Props> = ({ to, Icon, text, ...styleProps }) => {
+export const NavIconText: React.FC<Props> = ({ to, Icon, text }) => {
   return (
-    <NavIconTextStyle to={to} {...styleProps}>
-      <Icon {...IconStyleProps({ ...styleProps })} />
+    <NavIconTextStyle to={to}>
+      <Icon {...IconStyleProps()} />
       <span className="icontext_label">{text}</span>
     </NavIconTextStyle>
   );

--- a/src/components/SideMenu/components/NavIconText/NavIconTextStyle.tsx
+++ b/src/components/SideMenu/components/NavIconText/NavIconTextStyle.tsx
@@ -3,8 +3,6 @@ import { IconProps } from "components/icons/components/IconPrototype/IconPrototy
 import { FlexGap } from "styles/Utils/FlexGap";
 import { NavLink } from "react-router-dom";
 
-export type NavIconTextStyleProps = {};
-
 const defaultStyle = css`
   display: flex;
   flex-direction: row;
@@ -41,7 +39,7 @@ const activeStyle = css`
   }
 `;
 
-export const NavIconTextStyle = styled(NavLink)<NavIconTextStyleProps>`
+export const NavIconTextStyle = styled(NavLink)`
   ${defaultStyle}
 
   &:not(.active):hover {
@@ -55,7 +53,7 @@ export const NavIconTextStyle = styled(NavLink)<NavIconTextStyleProps>`
 
 NavIconTextStyle.defaultProps = {};
 
-export const IconStyleProps: (props: NavIconTextStyleProps) => IconProps = () => {
+export const IconStyleProps: () => IconProps = () => {
   return {
     size: "24px",
   };

--- a/src/hooks/ModerateSoundResources/useModerateSound.ts
+++ b/src/hooks/ModerateSoundResources/useModerateSound.ts
@@ -1,0 +1,43 @@
+import { useMemo, useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Dict } from "Types/Utils";
+import { RootState } from "store";
+import { loadModerateSoundUrl, ModerateSound } from "services/ModerateSounds/ModerateSounds";
+
+export type IResponse = {
+  moderateSounds: Dict<ModerateSound>;
+  groupedModerateSoundIds: {
+    start: string[];
+    remain5: string[];
+    finish: string[];
+  };
+  loadUrl: (moderateSoundId: string) => Promise<void>;
+};
+
+export const useModerateSound = (): IResponse => {
+  const { moderateSounds } = useSelector((state: RootState) => state.moderateSounds);
+  const dispatch = useDispatch();
+
+  const filterByType = useCallback((moderateSounds: Dict<ModerateSound>, type: string) => {
+    return Object.keys(moderateSounds).filter((id) => moderateSounds[id].type === type);
+  }, []);
+
+  const groupedModerateSoundIds = useMemo(
+    () => ({
+      start: filterByType(moderateSounds, "start"),
+      remain5: filterByType(moderateSounds, "remain5"),
+      finish: filterByType(moderateSounds, "finish"),
+    }),
+    [moderateSounds]
+  );
+
+  const loadUrl = async (moderateSoundId: string) => {
+    await dispatch(loadModerateSoundUrl(moderateSoundId));
+  };
+
+  return {
+    moderateSounds,
+    groupedModerateSoundIds,
+    loadUrl,
+  };
+};

--- a/src/hooks/PlaySound/usePlaySound.ts
+++ b/src/hooks/PlaySound/usePlaySound.ts
@@ -1,0 +1,32 @@
+import { useMemo, useCallback, useState } from "react";
+
+export type IResponse = {
+  playSound: (soundUrl?: string) => void;
+  changeVolume: (volume: number) => void;
+};
+
+export const usePlaySound = (): IResponse => {
+  const audio = useMemo(() => new Audio(), []);
+  const [volume, setVolume] = useState(1);
+
+  const playSound = useCallback(
+    (soundUrl?: string) => {
+      console.log(soundUrl);
+      if (audio && soundUrl) {
+        audio.src = soundUrl;
+        audio.volume = volume;
+        audio.play();
+      }
+    },
+    [audio, volume]
+  );
+
+  const changeVolume = useCallback((newVolume: number) => {
+    setVolume(newVolume < 0 ? 0 : newVolume > 1 ? 1 : newVolume);
+  }, []);
+
+  return {
+    playSound,
+    changeVolume,
+  };
+};

--- a/src/hooks/RealtimeGrandPrix/useRealtimeGrandPrix.ts
+++ b/src/hooks/RealtimeGrandPrix/useRealtimeGrandPrix.ts
@@ -20,6 +20,7 @@ import {
 } from "services/RealtimeGrandPrix/RealtimeGrandPrix";
 import { nullable, ThunkResult } from "services/Utils/Types";
 import { RootState } from "store";
+import { PRESENTATION_TIME } from "styles/constants/constants";
 import { stopResourceDBSync } from "./useRealtimeGrandPrixSetup";
 
 export const useRealtimeGrandPrix = () => {
@@ -85,7 +86,7 @@ export const createGrandPrixAsync = (grandPrixId: string): ThunkResult<void> => 
     if (!data) {
       await setGrandPrixAsync(grandPrixId, {
         enabled: true,
-        presentationTime: new Date(600000), // 初期値は10分
+        presentationTime: new Date(PRESENTATION_TIME), // 初期値は10分
       });
     }
     //グランプリが存在したら入室処理

--- a/src/hooks/ResourceList/useEditableResources.ts
+++ b/src/hooks/ResourceList/useEditableResources.ts
@@ -46,12 +46,13 @@ export const useEditableResourceState = <T extends object>(
   initialState: T,
   selector: (state: RootState) => T,
   validations: {
-    [P in keyof T]: (value: T[P]) => boolean;
+    [P in keyof T]: (value: T[P] | undefined) => boolean;
   },
   addResourceWithSaving?: (id: string, data: T) => void,
   updateResourceWithSaving?: (id: string, data: T) => void,
   removeResourceWithSaving?: (id: string) => void,
-  removeListener?: (id: string) => void
+  removeListener?: (id: string) => void,
+  toOld?: (id: string) => void
 ): IResponse<T> => {
   const resource = useSelector(selector);
   const [editableResource, setEditableResource] = useState<T>(resource ? resource : { ...initialState });
@@ -75,10 +76,10 @@ export const useEditableResourceState = <T extends object>(
     fields[key] = {
       value: editableResource[key],
       changeHandler: (value: T[typeof key]) => {
-        setEditableResource({
-          ...editableResource,
+        setEditableResource((current) => ({
+          ...current,
           [key]: value,
-        });
+        }));
         setIsChange(true);
       },
     };
@@ -138,7 +139,7 @@ export const useEditableResourceState = <T extends object>(
       if (addResourceWithSaving) {
         await dispatch(addResourceWithSaving(id, editableResource));
       }
-      if (removeListener) removeListener(id);
+      if (toOld) toOld(id);
     } else {
       if (updateResourceWithSaving) {
         await dispatch(updateResourceWithSaving(id, editableResource));

--- a/src/hooks/ResourceList/useResourceListState.ts
+++ b/src/hooks/ResourceList/useResourceListState.ts
@@ -12,6 +12,7 @@ export type IResponse = {
   resourceSortedKeys: string[];
   addResourceBtnHandler: () => void;
   removeListener: (id: string) => void;
+  toOld: (id: string) => void;
 };
 
 export const useResourceListState = <T extends object>(
@@ -45,9 +46,22 @@ export const useResourceListState = <T extends object>(
   };
 
   const _removeListener = (id: string) => {
-    delete editableResources[id];
-    setEditableResources({ ...editableResources });
-    _updateKeys(editableResources);
+    setEditableResources((current) => {
+      delete current[id];
+      _updateKeys(current);
+      return current;
+    });
+  };
+
+  const _toOld = (id: string) => {
+    const updated = {
+      ...editableResources,
+      [id]: {
+        isNew: false,
+      },
+    };
+    setEditableResources(updated);
+    _updateKeys(updated);
   };
 
   const _updateKeys = (resources: Dict<EditableResourceRequire>) => {
@@ -59,5 +73,6 @@ export const useResourceListState = <T extends object>(
     resourceSortedKeys: resourceKeys,
     addResourceBtnHandler: _addResourceBtnHandler,
     removeListener: _removeListener,
+    toOld: _toOld,
   };
 };

--- a/src/hooks/Setup/useSetup.ts
+++ b/src/hooks/Setup/useSetup.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { reloadGrandPrixesAsync } from "services/GrandPrixes/GrandPrixes";
+import { reloadModerateSoundsAsync } from "services/ModerateSounds/ModerateSounds";
 import { reloadStampsAsync } from "services/Stamps/Stamps";
 import { reloadStampTypesAsync } from "services/StampTypes/StampTypes";
 import { reloadUserDataAsync } from "services/User/User";
@@ -21,6 +22,7 @@ export const useSetup = (): IResponse => {
     dispatch(reloadStampsAsync());
     dispatch(reloadStampTypesAsync());
     dispatch(reloadGrandPrixesAsync());
+    dispatch(reloadModerateSoundsAsync());
   };
 
   return {

--- a/src/hooks/WatchDog/usePresentationWatchDog.ts
+++ b/src/hooks/WatchDog/usePresentationWatchDog.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { ModerateSound } from "services/ModerateSounds/ModerateSounds";
+import { useWatchDog } from "./useWatchDog";
+
+export type WatchDogType = {
+  startTime?: Date;
+  maxTime: Date;
+  /** イベント発生時間（絶対日付） */
+  eventTimePattern: ModerateSound["type"];
+  /** イベント関数 */
+  eventFunc: () => void;
+};
+
+type HookType = (props: WatchDogType) => void;
+
+export const usePresentationWatchDog: HookType = ({ startTime, maxTime, eventTimePattern, eventFunc }) => {
+  const eventTime = new Date(
+    startTime ? maxTime.getTime() + startTime.getTime() - (eventTimePattern === "remain5" ? 5 * 60 * 1000 : 0) : 0
+  );
+
+  useWatchDog({
+    enabled: !!startTime && eventTimePattern !== "start",
+    eventTime,
+    eventFunc,
+  });
+
+  useEffect(() => {
+    if (!!startTime && eventTimePattern === "start") {
+      eventFunc();
+    }
+  }, [startTime]);
+};

--- a/src/hooks/WatchDog/useWatchDog.ts
+++ b/src/hooks/WatchDog/useWatchDog.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from "react";
+
+export type WatchDogType = {
+  enabled: boolean;
+  /** イベント発生時間（絶対日付） */
+  eventTime: Date;
+  /** イベント関数 */
+  eventFunc: () => void;
+};
+
+type HookType = (props: WatchDogType) => void;
+
+export const useWatchDog: HookType = ({ enabled, eventTime, eventFunc }) => {
+  const [timeoutId, setTimeoutId] = useState<number>();
+
+  useEffect(() => {
+    if (timeoutId) {
+      window.clearTimeout(timeoutId);
+      setTimeoutId(undefined);
+    }
+
+    if (!enabled) return;
+
+    const timer = eventTime.getTime() - new Date().getTime();
+
+    if (timer < 0) return;
+
+    const id = window.setTimeout(eventFunc, timer);
+    setTimeoutId(id);
+  }, [enabled]);
+};

--- a/src/pages/Admin/GrandPrixController/components/EditablePresenter/hooks/useEditablePresenterState.ts
+++ b/src/pages/Admin/GrandPrixController/components/EditablePresenter/hooks/useEditablePresenterState.ts
@@ -34,7 +34,7 @@ export const useEditablePresenterState = (grandPrixId: string, presenterId: stri
       state.grandPrixes.presenters[grandPrixId] && state.grandPrixes.presenters[grandPrixId][presenterId],
     {
       index: () => true,
-      earnedCollvoPoint: (value) => value >= 0,
+      earnedCollvoPoint: (value) => value !== undefined && value >= 0,
       nextDescription: () => true,
     },
     undefined,

--- a/src/pages/Admin/GrandPrixController/hooks/useGrandPrixControllerState.ts
+++ b/src/pages/Admin/GrandPrixController/hooks/useGrandPrixControllerState.ts
@@ -5,6 +5,7 @@ import { useRealtimeGrandPrixSetup } from "hooks/RealtimeGrandPrix/useRealtimeGr
 import { useTimer } from "hooks/Timer/useTimer";
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
+import { PRESENTATION_TIME } from "styles/constants/constants";
 import { ButtonOpts, Dict } from "Types/Utils";
 
 export const Status = {
@@ -99,7 +100,7 @@ export const useGrandPrixControllerState = () => {
   };
 
   // タイマー機能
-  const initialTime = new Date(600000);
+  const initialTime = new Date(PRESENTATION_TIME);
   const { remainTime } = useTimer({
     maxTime: realtimeGrandPrix.grandPrix?.presentationTime || initialTime,
     startTime: realtimeGrandPrix.grandPrix?.startTime,

--- a/src/pages/Admin/Top/AdminTop.tsx
+++ b/src/pages/Admin/Top/AdminTop.tsx
@@ -1,6 +1,7 @@
 import { WithHeaderFooter } from "components/Layout/WithHeaderFooter/WithHeaderFooter";
 import React from "react";
 import { GrandPrixList } from "./components/GrandPrixList/GrandPrixList";
+import { ModerateSoundList } from "./components/ModerateSoundList/ModerateSoundList";
 import { StampList } from "./components/StampList/StampList";
 import { StampTypeList } from "./components/StampTypeList/StampTypeList";
 
@@ -16,6 +17,8 @@ export const AdminTop: React.FC<Props> = () => {
       <StampList />
       <h3>グランプリ一覧</h3>
       <GrandPrixList />
+      <h3>プレゼンテーション進行ボイス一覧</h3>
+      <ModerateSoundList />
     </WithHeaderFooter>
   );
 };

--- a/src/pages/Admin/Top/components/EditableGrandPrix/EditableGrandPrix.tsx
+++ b/src/pages/Admin/Top/components/EditableGrandPrix/EditableGrandPrix.tsx
@@ -13,9 +13,10 @@ type Props = {
   grandPrixId: string;
   isNew: boolean;
   removeListener?: (id: string) => void;
+  toOld?: (id: string) => void;
 };
 
-export const EditableGrandPrix: React.FC<Props> = ({ grandPrixId, isNew, removeListener }) => {
+export const EditableGrandPrix: React.FC<Props> = ({ grandPrixId, isNew, removeListener, toOld }) => {
   const {
     editableGrandPrix: grandPrix,
     statusList,
@@ -26,7 +27,7 @@ export const EditableGrandPrix: React.FC<Props> = ({ grandPrixId, isNew, removeL
     saveBtn,
     closeBtn,
     removeBtn,
-  } = useEditableGrandPrixState(grandPrixId, isNew, removeListener);
+  } = useEditableGrandPrixState(grandPrixId, isNew, removeListener, toOld);
 
   return (
     <ul>

--- a/src/pages/Admin/Top/components/EditableGrandPrix/hooks/useEditableGrandPrixState.ts
+++ b/src/pages/Admin/Top/components/EditableGrandPrix/hooks/useEditableGrandPrixState.ts
@@ -39,7 +39,8 @@ export type IResponse = {
 export const useEditableGrandPrixState = (
   GrandPrixId: string,
   isNew: boolean,
-  removeListener?: (id: string) => void
+  removeListener?: (id: string) => void,
+  toOld?: (id: string) => void
 ): IResponse => {
   const state = useEditableResourceState<GrandPrix>(
     GrandPrixId,
@@ -55,11 +56,11 @@ export const useEditableGrandPrixState = (
     },
     (state: RootState) => state.grandPrixes.grandPrixes[GrandPrixId],
     {
-      subtitle: (value) => value != "",
-      number: (value) => value >= 0,
-      eventDate: (value) => isDate(value),
-      status: (value) => value in Object.values(GrandPrixStatus),
-      description: (value) => value != "",
+      subtitle: (value) => value !== undefined && value != "",
+      number: (value) => value !== undefined && value >= 0,
+      eventDate: (value) => value !== undefined && isDate(value),
+      status: (value) => value !== undefined && value in Object.values(GrandPrixStatus),
+      description: (value) => value !== undefined && value != "",
       isDraft: () => true,
       // 但し、UI上には表示しない
       isDistributed: () => true,
@@ -67,7 +68,8 @@ export const useEditableGrandPrixState = (
     addGrandPrixWithSaving,
     updateGrandPrixWithSaving,
     removeGrandPrixWithSaving,
-    removeListener
+    removeListener,
+    toOld
   );
   const grandPrixStatusKeys = Object.keys(GrandPrixStatus) as [keyof typeof GrandPrixStatus];
   const statusList = grandPrixStatusKeys.map((key) => {

--- a/src/pages/Admin/Top/components/EditableModerateSound/EditableModerateSound.tsx
+++ b/src/pages/Admin/Top/components/EditableModerateSound/EditableModerateSound.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { useEditableModerateSoundState } from "./hooks/useEditableModerateSoundState";
+import { ResourceStatus } from "components/EditableResourcesElements/ResourceStatus";
+import { ResourceButtons } from "components/EditableResourcesElements/ResourceButtons";
+import { EditableInputText } from "components/EditableResourcesElements/EditableInputText";
+import { EditableSelect } from "components/EditableResourcesElements/EditableSelect";
+import { EditableInputFile } from "components/EditableResourcesElements/EditableInputFile";
+
+type Props = {
+  moderateSoundId: string;
+  isNew: boolean;
+  removeListener?: (id: string) => void;
+  toOld?: (id: string) => void;
+};
+
+export const EditableModerateSound: React.FC<Props> = ({ moderateSoundId, isNew, removeListener, toOld }) => {
+  const {
+    editableModerateSound: moderateSound,
+    typeSelects,
+    isEdit,
+    isChange,
+    status,
+    editStartBtn,
+    saveBtn,
+    closeBtn,
+    removeBtn,
+    soundDataURL,
+    onChangeSoundFile,
+  } = useEditableModerateSoundState(moderateSoundId, isNew, removeListener, toOld);
+
+  return (
+    <ul>
+      <li>
+        <ResourceStatus status={status} isEdit={isEdit} />
+      </li>
+      <li>
+        進行ボイス名：
+        <EditableInputText
+          isEdit={isEdit}
+          value={moderateSound.name.value}
+          onChange={moderateSound.name.changeHandler}
+        />
+      </li>
+      <li>
+        ボイスタイプ：
+        <EditableSelect
+          isEdit={isEdit}
+          value={moderateSound.type.value}
+          selects={typeSelects}
+          onChange={moderateSound.type.changeHandler as any}
+        />
+      </li>
+      <li>
+        音声ファイル：
+        <EditableInputFile isEdit={isEdit} value={moderateSound.filename.value} onChange={onChangeSoundFile} />
+      </li>
+      <li>
+        <button
+          onClick={() => {
+            new Audio(soundDataURL).play();
+          }}
+        >
+          再生
+        </button>
+      </li>
+      <li>
+        <ResourceButtons
+          isEdit={isEdit}
+          isChange={isChange}
+          saveBtn={saveBtn}
+          closeBtn={closeBtn}
+          removeBtn={removeBtn}
+          editStartBtn={editStartBtn}
+        />
+      </li>
+    </ul>
+  );
+};

--- a/src/pages/Admin/Top/components/EditableModerateSound/hooks/useEditableModerateSoundState.ts
+++ b/src/pages/Admin/Top/components/EditableModerateSound/hooks/useEditableModerateSoundState.ts
@@ -1,0 +1,148 @@
+import { useEffect, useState } from "react";
+import { RootState } from "store";
+import { useModerateSound } from "hooks/ModerateSoundResources/useModerateSound";
+import { FieldType, StatusType, useEditableResourceState } from "hooks/ResourceList/useEditableResources";
+import {
+  addModerateSoundWithSaving,
+  removeModerateSoundWithSaving,
+  ModerateSound,
+  updateModerateSoundWithSaving,
+  SavedModerateSound,
+} from "services/ModerateSounds/ModerateSounds";
+
+export type IResponse = {
+  editableModerateSound: FieldType<ModerateSound>;
+  typeSelects: {
+    label: string;
+    value: string;
+  }[];
+  isEdit: boolean;
+  isChange: boolean;
+  status: StatusType;
+  editStartBtn: {
+    clickHandler: () => void;
+    disabled: boolean;
+  };
+  saveBtn: {
+    clickHandler: () => void;
+    disabled: boolean;
+  };
+  closeBtn: {
+    clickHandler: () => void;
+    disabled: boolean;
+  };
+  removeBtn: {
+    clickHandler: () => void;
+    disabled: boolean;
+  };
+  soundDataURL: string;
+  onChangeSoundFile: (value: File) => void;
+};
+
+export const useEditableModerateSoundState = (
+  moderateSoundId: string,
+  isNew: boolean,
+  removeListener?: (id: string) => void,
+  toOld?: (id: string) => void
+): IResponse => {
+  const { moderateSounds, loadUrl } = useModerateSound();
+  const [soundFileReader] = useState({
+    asUrl: new FileReader(),
+    asArray: new FileReader(),
+  });
+  const [soundDataURL, setSoundDataURL] = useState("");
+  const [soundDataArray, setSoundDataArray] = useState<ArrayBuffer>();
+
+  const state = useEditableResourceState<SavedModerateSound>(
+    moderateSoundId,
+    isNew,
+    {
+      name: "",
+      type: "start",
+      filename: "",
+      file: new Blob(),
+    },
+    (state: RootState) =>
+      state.moderateSounds.moderateSounds[moderateSoundId] && {
+        ...state.moderateSounds.moderateSounds[moderateSoundId],
+        // TODO: 初期値を空データにしているため、編集ボタンを押すとデータがリセットされる
+        file: soundDataArray || new Blob(),
+      },
+    {
+      name: (value) => value !== undefined && value !== "",
+      type: (value) => value !== undefined && ["start", "remain5", "finish"].includes(value),
+      filename: (value) => value !== undefined && value !== "",
+      file: (value) => value !== undefined,
+    },
+    addModerateSoundWithSaving,
+    updateModerateSoundWithSaving,
+    removeModerateSoundWithSaving,
+    removeListener,
+    toOld
+  );
+
+  useEffect(() => {
+    loadUrl(moderateSoundId);
+    setSoundDataArray(undefined);
+  }, []);
+
+  useEffect(() => {
+    const downloadURL = moderateSounds[moderateSoundId]?.downloadURL;
+    if (downloadURL) {
+      setSoundDataURL(downloadURL);
+    }
+  }, [moderateSounds[moderateSoundId]?.downloadURL]);
+
+  useEffect(() => {
+    soundFileReader.asUrl.onload = (reader) => {
+      const result = reader.target?.result;
+      if (result) {
+        if (typeof result === "string") {
+          setSoundDataURL(result);
+        }
+      }
+    };
+    soundFileReader.asArray.onload = (reader) => {
+      const result = reader.target?.result;
+      if (result) {
+        if (typeof result !== "string") {
+          setSoundDataArray(result);
+          state.fields.file.changeHandler(result);
+        }
+      }
+    };
+  }, []);
+
+  const _onChangeSoundFile = (value: File) => {
+    state.fields.filename.changeHandler(value.name);
+    soundFileReader.asUrl.readAsDataURL(value);
+    soundFileReader.asArray.readAsArrayBuffer(value);
+  };
+
+  return {
+    editableModerateSound: state.fields,
+    typeSelects: [
+      {
+        value: "start",
+        label: "開始時",
+      },
+      {
+        value: "remain5",
+        label: "残り５分",
+      },
+      {
+        value: "finish",
+        label: "終了時",
+      },
+    ],
+    isEdit: state.isEdit,
+    isChange: state.isChange,
+    status: state.status,
+    editStartBtn: state.editStartBtn,
+    saveBtn: state.saveBtn,
+    closeBtn: state.closeBtn,
+    removeBtn: state.removeBtn,
+    soundDataURL: soundDataURL,
+    onChangeSoundFile: _onChangeSoundFile,
+  };
+};

--- a/src/pages/Admin/Top/components/EditableStampInfo/EditableStampInfo.tsx
+++ b/src/pages/Admin/Top/components/EditableStampInfo/EditableStampInfo.tsx
@@ -11,9 +11,10 @@ type Props = {
   stampId: string;
   isNew: boolean;
   removeListener?: (id: string) => void;
+  toOld?: (id: string) => void;
 };
 
-export const EditableStampInfo: React.FC<Props> = ({ stampId, isNew, removeListener }) => {
+export const EditableStampInfo: React.FC<Props> = ({ stampId, isNew, removeListener, toOld }) => {
   const {
     editableStamp: stamp,
     stampTypeSelects,
@@ -28,7 +29,7 @@ export const EditableStampInfo: React.FC<Props> = ({ stampId, isNew, removeListe
     soundDataURL,
     onChangeImageFile,
     onChangeSoundFile,
-  } = useEditableStampInfoState(stampId, isNew, removeListener);
+  } = useEditableStampInfoState(stampId, isNew, removeListener, toOld);
 
   return (
     <ul>

--- a/src/pages/Admin/Top/components/EditableStampInfo/hooks/useEditableStampInfoState.ts
+++ b/src/pages/Admin/Top/components/EditableStampInfo/hooks/useEditableStampInfoState.ts
@@ -49,7 +49,8 @@ export type IResponse = {
 export const useEditableStampInfoState = (
   stampId: string,
   isNew: boolean,
-  removeListener?: (id: string) => void
+  removeListener?: (id: string) => void,
+  toOld?: (id: string) => void
 ): IResponse => {
   const stampTypes = useSelector((state: RootState) => state.stampTypes.stampTypes);
   const [uploadStatus, setUploadStatus] = useState<UploadStatusType>(UploadStatus.standBy);
@@ -81,15 +82,16 @@ export const useEditableStampInfoState = (
     },
     (state: RootState) => state.stamps.stamps[stampId],
     {
-      name: (value: string) => value != "",
-      typeId: (value: string) => value in stampTypes,
-      imageURL: (value: string) => value != "",
-      soundURL: (value: string) => value != "",
+      name: (value) => value !== undefined && value != "",
+      typeId: (value) => value !== undefined && value in stampTypes,
+      imageURL: (value) => value !== undefined && value != "",
+      soundURL: (value) => value !== undefined && value != "",
     },
     addStampWithSaving,
     updateStampWithSaving,
     removeStampWithSaving,
-    removeListener
+    removeListener,
+    toOld
   );
 
   useEffect(() => {

--- a/src/pages/Admin/Top/components/EditableStampType/EditableStampType.tsx
+++ b/src/pages/Admin/Top/components/EditableStampType/EditableStampType.tsx
@@ -9,9 +9,10 @@ type Props = {
   stampTypeId: string;
   isNew: boolean;
   removeListener?: (id: string) => void;
+  toOld?: (id: string) => void;
 };
 
-export const EditableStampTypeInfo: React.FC<Props> = ({ stampTypeId, isNew, removeListener }) => {
+export const EditableStampTypeInfo: React.FC<Props> = ({ stampTypeId, isNew, removeListener, toOld }) => {
   const {
     editableStampType: stampType,
     isEdit,
@@ -21,7 +22,7 @@ export const EditableStampTypeInfo: React.FC<Props> = ({ stampTypeId, isNew, rem
     saveBtn,
     closeBtn,
     removeBtn,
-  } = useEditableStampTypeState(stampTypeId, isNew, removeListener);
+  } = useEditableStampTypeState(stampTypeId, isNew, removeListener, toOld);
 
   return (
     <ul>

--- a/src/pages/Admin/Top/components/EditableStampType/hooks/useEditableStampTypeState.ts
+++ b/src/pages/Admin/Top/components/EditableStampType/hooks/useEditableStampTypeState.ts
@@ -33,7 +33,8 @@ export type IResponse = {
 export const useEditableStampTypeState = (
   stampTypeId: string,
   isNew: boolean,
-  removeListener?: (id: string) => void
+  removeListener?: (id: string) => void,
+  toOld?: (id: string) => void
 ): IResponse => {
   const state = useEditableResourceState<StampType>(
     stampTypeId,
@@ -44,13 +45,14 @@ export const useEditableStampTypeState = (
     },
     (state: RootState) => state.stampTypes.stampTypes[stampTypeId],
     {
-      name: (value: string) => value != "",
-      description: (value: string) => value != "",
+      name: (value) => value !== undefined && value != "",
+      description: (value) => value !== undefined && value != "",
     },
     addStampTypeWithSaving,
     updateStampTypeWithSaving,
     removeStampTypeWithSaving,
-    removeListener
+    removeListener,
+    toOld
   );
 
   return {

--- a/src/pages/Admin/Top/components/GrandPrixList/GrandPrixList.tsx
+++ b/src/pages/Admin/Top/components/GrandPrixList/GrandPrixList.tsx
@@ -5,12 +5,17 @@ import { useGrandPrixListState } from "./hooks/useGrandPrixListState";
 type Props = {};
 
 export const GrandPrixList: React.FC<Props> = () => {
-  const { grandPrixes, grandPrixSortedKeys, addGrandPrixBtnHandler, removeListener } = useGrandPrixListState();
+  const { grandPrixes, grandPrixSortedKeys, addGrandPrixBtnHandler, removeListener, toOld } = useGrandPrixListState();
   return (
     <ul>
       {grandPrixSortedKeys.map((key) => (
         <li key={key}>
-          <EditableGrandPrix grandPrixId={key} isNew={grandPrixes[key].isNew} removeListener={removeListener} />
+          <EditableGrandPrix
+            grandPrixId={key}
+            isNew={grandPrixes[key].isNew}
+            removeListener={removeListener}
+            toOld={toOld}
+          />
         </li>
       ))}
       <li>

--- a/src/pages/Admin/Top/components/GrandPrixList/hooks/useGrandPrixListState.ts
+++ b/src/pages/Admin/Top/components/GrandPrixList/hooks/useGrandPrixListState.ts
@@ -8,18 +8,18 @@ export type IResponse = {
   grandPrixSortedKeys: string[];
   addGrandPrixBtnHandler: () => void;
   removeListener: (id: string) => void;
+  toOld: (id: string) => void;
 };
 
 export const useGrandPrixListState = (): IResponse => {
-  const { resources, resourceSortedKeys, addResourceBtnHandler, removeListener } = useResourceListState<GrandPrix>(
-    generateGrandPrixId,
-    (state: RootState) => state.grandPrixes.grandPrixes
-  );
+  const { resources, resourceSortedKeys, addResourceBtnHandler, removeListener, toOld } =
+    useResourceListState<GrandPrix>(generateGrandPrixId, (state: RootState) => state.grandPrixes.grandPrixes);
 
   return {
     grandPrixes: resources,
     grandPrixSortedKeys: resourceSortedKeys,
     addGrandPrixBtnHandler: addResourceBtnHandler,
-    removeListener: removeListener,
+    removeListener,
+    toOld,
   };
 };

--- a/src/pages/Admin/Top/components/ModerateSoundList/ModerateSoundList.tsx
+++ b/src/pages/Admin/Top/components/ModerateSoundList/ModerateSoundList.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { EditableModerateSound } from "../EditableModerateSound/EditableModerateSound";
+import { useModerateSoundListState } from "./hooks/useModerateSoundListState";
+
+type Props = {};
+
+export const ModerateSoundList: React.FC<Props> = () => {
+  const { moderateSounds, moderateSoundSortedKeys, addModerateSoundBtnHandler, removeListener, toOld } =
+    useModerateSoundListState();
+  return (
+    <ul>
+      {moderateSoundSortedKeys.map((key) => (
+        <li key={key}>
+          <EditableModerateSound
+            moderateSoundId={key}
+            isNew={moderateSounds[key].isNew}
+            removeListener={removeListener}
+            toOld={toOld}
+          />
+        </li>
+      ))}
+      <li>
+        <button onClick={addModerateSoundBtnHandler}>追加</button>
+      </li>
+    </ul>
+  );
+};

--- a/src/pages/Admin/Top/components/ModerateSoundList/hooks/useModerateSoundListState.ts
+++ b/src/pages/Admin/Top/components/ModerateSoundList/hooks/useModerateSoundListState.ts
@@ -1,0 +1,28 @@
+import { EditableResourceRequire, useResourceListState } from "hooks/ResourceList/useResourceListState";
+import { generateModerateSoundId, ModerateSound } from "services/ModerateSounds/ModerateSounds";
+import { RootState } from "store";
+import { Dict } from "Types/Utils";
+
+export type IResponse = {
+  moderateSounds: Dict<EditableResourceRequire>;
+  moderateSoundSortedKeys: string[];
+  addModerateSoundBtnHandler: () => void;
+  removeListener: (id: string) => void;
+  toOld: (id: string) => void;
+};
+
+export const useModerateSoundListState = (): IResponse => {
+  const { resources, resourceSortedKeys, addResourceBtnHandler, removeListener, toOld } =
+    useResourceListState<ModerateSound>(
+      generateModerateSoundId,
+      (state: RootState) => state.moderateSounds.moderateSounds
+    );
+
+  return {
+    moderateSounds: resources,
+    moderateSoundSortedKeys: resourceSortedKeys,
+    addModerateSoundBtnHandler: addResourceBtnHandler,
+    removeListener,
+    toOld,
+  };
+};

--- a/src/pages/Admin/Top/components/StampList/StampList.tsx
+++ b/src/pages/Admin/Top/components/StampList/StampList.tsx
@@ -5,12 +5,12 @@ import { useStampListState } from "./hooks/useStampListState";
 type Props = {};
 
 export const StampList: React.FC<Props> = () => {
-  const { stamps, stampSortedKeys, addStampBtnHandler, removeListener } = useStampListState();
+  const { stamps, stampSortedKeys, addStampBtnHandler, removeListener, toOld } = useStampListState();
   return (
     <ul>
       {stampSortedKeys.map((key) => (
         <li key={key}>
-          <EditableStampInfo stampId={key} isNew={stamps[key].isNew} removeListener={removeListener} />
+          <EditableStampInfo stampId={key} isNew={stamps[key].isNew} removeListener={removeListener} toOld={toOld} />
         </li>
       ))}
       <li>

--- a/src/pages/Admin/Top/components/StampList/hooks/useStampListState.ts
+++ b/src/pages/Admin/Top/components/StampList/hooks/useStampListState.ts
@@ -8,10 +8,11 @@ export type IResponse = {
   stampSortedKeys: string[];
   addStampBtnHandler: () => void;
   removeListener: (id: string) => void;
+  toOld: (id: string) => void;
 };
 
 export const useStampListState = (): IResponse => {
-  const { resources, resourceSortedKeys, addResourceBtnHandler, removeListener } = useResourceListState<Stamp>(
+  const { resources, resourceSortedKeys, addResourceBtnHandler, removeListener, toOld } = useResourceListState<Stamp>(
     generateId,
     (state: RootState) => state.stamps.stamps
   );
@@ -20,6 +21,7 @@ export const useStampListState = (): IResponse => {
     stamps: resources,
     stampSortedKeys: resourceSortedKeys,
     addStampBtnHandler: addResourceBtnHandler,
-    removeListener: removeListener,
+    removeListener,
+    toOld,
   };
 };

--- a/src/pages/Admin/Top/components/StampTypeList/StampTypeList.tsx
+++ b/src/pages/Admin/Top/components/StampTypeList/StampTypeList.tsx
@@ -5,12 +5,17 @@ import { useStampTypeListState } from "./hooks/useStampTypeListState";
 type Props = {};
 
 export const StampTypeList: React.FC<Props> = () => {
-  const { stampTypes, stampTypeSortedKeys, addStampTypeBtnHandler, removeListener } = useStampTypeListState();
+  const { stampTypes, stampTypeSortedKeys, addStampTypeBtnHandler, removeListener, toOld } = useStampTypeListState();
   return (
     <ul>
       {stampTypeSortedKeys.map((key) => (
         <li key={key}>
-          <EditableStampTypeInfo stampTypeId={key} isNew={stampTypes[key].isNew} removeListener={removeListener} />
+          <EditableStampTypeInfo
+            stampTypeId={key}
+            isNew={stampTypes[key].isNew}
+            removeListener={removeListener}
+            toOld={toOld}
+          />
         </li>
       ))}
       <li>

--- a/src/pages/Admin/Top/components/StampTypeList/hooks/useStampTypeListState.ts
+++ b/src/pages/Admin/Top/components/StampTypeList/hooks/useStampTypeListState.ts
@@ -8,18 +8,18 @@ export type IResponse = {
   stampTypeSortedKeys: string[];
   addStampTypeBtnHandler: () => void;
   removeListener: (id: string) => void;
+  toOld: (id: string) => void;
 };
 
 export const useStampTypeListState = (): IResponse => {
-  const { resources, resourceSortedKeys, addResourceBtnHandler, removeListener } = useResourceListState<StampType>(
-    generateId,
-    (state: RootState) => state.stampTypes.stampTypes
-  );
+  const { resources, resourceSortedKeys, addResourceBtnHandler, removeListener, toOld } =
+    useResourceListState<StampType>(generateId, (state: RootState) => state.stampTypes.stampTypes);
 
   return {
     stampTypes: resources,
     stampTypeSortedKeys: resourceSortedKeys,
     addStampTypeBtnHandler: addResourceBtnHandler,
-    removeListener: removeListener,
+    removeListener,
+    toOld,
   };
 };

--- a/src/services/ModerateSounds/ModerateSounds.ts
+++ b/src/services/ModerateSounds/ModerateSounds.ts
@@ -1,0 +1,219 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { collection, doc, UpdateData, WithFieldValue } from "firebase/firestore";
+import { ref } from "firebase/storage";
+import { getFirestore, getStorage } from "firebase_config";
+import { PartialFieldValue, PayloadWithId, ThunkResult } from "services/Utils/Types";
+import { Dict } from "Types/Utils";
+import {
+  getModerateSoundsAsync,
+  getModerateSoundURLFromStorageAsync,
+  removeModerateSoundAsync,
+  removeModerateSoundFromStorageAsync,
+  setModerateSoundAsync,
+  updateModerateSoundAsync,
+  uploadModerateSoundURLFromStorageAsync,
+} from "./SOperator/SOperator";
+
+export const ModerateSoundsRef = () => collection(getFirestore(), "ModerateSounds");
+export const ModerateSoundFilesRef = () => ref(getStorage(), "ModerateSound");
+
+export type ModerateSound = {
+  name: string;
+  type: "start" | "remain5" | "finish";
+  filename: string;
+  downloadURL?: string;
+};
+
+export type ModerateSoundOnDB = Omit<ModerateSound, "downloadURL">;
+
+export const isModerateSound = (instance: any): instance is ModerateSound =>
+  instance !== undefined &&
+  "name" in instance &&
+  "type" in instance &&
+  instance["type"] in ["start", "remain5", "finish"] &&
+  "filename" in instance;
+
+type UpdateModerateSound = Partial<ModerateSound>;
+
+export type ModerateSoundsState = {
+  moderateSounds: Dict<ModerateSound>;
+};
+
+export type ModerateSoundAddedToFirestore = WithFieldValue<ModerateSoundOnDB>;
+export type ModerateSoundUpdatedToFirestore = UpdateData<ModerateSoundOnDB>;
+export type ModerateSoundOperationOfFirestore = PartialFieldValue<ModerateSoundOnDB>;
+export type ModerateSoundPartial = Partial<ModerateSoundOnDB>;
+
+type ModerateSoundsPayload = PayloadAction<Dict<ModerateSound>>;
+type ModerateSoundPayload = PayloadWithId<ModerateSound>;
+type UpdateModerateSoundPayload = PayloadWithId<UpdateModerateSound>;
+
+export type UploadModerateSoundFile = Blob | Uint8Array | ArrayBuffer;
+
+const initialState: ModerateSoundsState = {
+  moderateSounds: {},
+};
+
+const moderateSoundsSlice = createSlice({
+  name: "moderateSounds",
+  initialState: { ...initialState } as ModerateSoundsState,
+  reducers: {
+    setModerateSounds: (state, action: ModerateSoundsPayload) => {
+      const moderateSounds = action.payload;
+      state.moderateSounds = moderateSounds;
+    },
+    setModerateSound: (state, action: ModerateSoundPayload) => {
+      const { id, data } = action.payload;
+      state.moderateSounds[id] = data;
+    },
+    updateModerateSound: (state, action: UpdateModerateSoundPayload) => {
+      const { id, data } = action.payload;
+      state.moderateSounds[id] = {
+        ...state.moderateSounds[id],
+        ...data,
+      };
+    },
+    removeModerateSound: (state, action: PayloadAction<string>) => {
+      const id = action.payload;
+      delete state.moderateSounds[id];
+    },
+    clearModerateSounds: (state) => {
+      Object.assign(state, initialState);
+    },
+  },
+});
+
+export const { setModerateSounds, setModerateSound, updateModerateSound, removeModerateSound, clearModerateSounds } =
+  moderateSoundsSlice.actions;
+
+// ---- Firestore ---- //
+
+export const reloadModerateSoundsAsync = (): ThunkResult<void> => {
+  return async (dispatch) => {
+    dispatch(clearModerateSounds());
+    const moderateSounds = await getModerateSoundsAsync();
+    if (moderateSounds) {
+      dispatch(setModerateSounds(moderateSounds));
+    }
+  };
+};
+
+export const generateModerateSoundId = () => {
+  return doc(ModerateSoundsRef()).id;
+};
+
+export const addModerateSoundWithSaving = (
+  moderateSoundId: string,
+  moderateSoundData: ModerateSoundOnDB,
+  moderateSoundFile: UploadModerateSoundFile,
+  operate?: ModerateSoundOperationOfFirestore
+): ThunkResult<void> => {
+  return async (dispatch) => {
+    // 新データを作成
+    const data: { [key: string]: any } = {};
+    const moderateSoundKeys = Object.keys(moderateSoundData) as [keyof ModerateSoundOnDB];
+    moderateSoundKeys.forEach((key) => {
+      data[key] = operate && operate[key] ? operate[key] : moderateSoundData[key];
+    });
+
+    //Firestoreに追加
+    await setModerateSoundAsync(moderateSoundId, data as ModerateSoundAddedToFirestore).then(() => {
+      dispatch(
+        setModerateSound({
+          id: moderateSoundId,
+          data: moderateSoundData,
+        })
+      );
+    });
+
+    // データをアップロード
+    await uploadModerateSoundURLFromStorageAsync(moderateSoundId, moderateSoundFile).catch(async () => {
+      // 失敗したらデータも削除
+      await removeModerateSoundAsync(moderateSoundId).then(async () => {
+        dispatch(removeModerateSound(moderateSoundId));
+      });
+    });
+  };
+};
+
+export const updateModerateSoundWithSaving = (
+  moderateSoundId: string,
+  moderateSoundData: ModerateSoundPartial,
+  moderateSoundFile?: UploadModerateSoundFile,
+  operate?: ModerateSoundOperationOfFirestore
+): ThunkResult<void> => {
+  return async (dispatch, getState) => {
+    // 新データを作成
+    const data: { [key: string]: any } = {};
+    const moderateSoundKeys = Object.keys(moderateSoundData) as [keyof ModerateSoundOnDB];
+    moderateSoundKeys.forEach((key) => {
+      data[key] = operate && operate[key] ? operate[key] : moderateSoundData[key];
+    });
+
+    //Firestoreに追加
+    await updateModerateSoundAsync(moderateSoundId, data as ModerateSoundUpdatedToFirestore).then(async () => {
+      // 前の状態を保持
+      const preModerateSound = getState().moderateSounds.moderateSounds[moderateSoundId];
+
+      // 分割データで来るので足りない部分をpreModerateSoundからコピーする
+      const updateData: { [key: string]: any } = {};
+      const moderateSoundKeys = Object.keys(preModerateSound) as [keyof ModerateSoundOnDB];
+      moderateSoundKeys.forEach((key) => {
+        updateData[key] = moderateSoundData[key] ? moderateSoundData[key] : preModerateSound[key];
+      });
+
+      // 即時反映するため仮想更新
+      dispatch(
+        updateModerateSound({
+          id: moderateSoundId,
+          data: updateData as ModerateSoundOnDB,
+        })
+      );
+    });
+
+    if (moderateSoundFile) {
+      await uploadModerateSoundURLFromStorageAsync(moderateSoundId, moderateSoundFile);
+    }
+  };
+};
+
+export const removeModerateSoundWithSaving = (moderateSoundId: string): ThunkResult<void> => {
+  return async (dispatch) => {
+    // Storageから削除
+    await removeModerateSoundFromStorageAsync(moderateSoundId).then(async () => {
+      // Firesotreから削除
+      await removeModerateSoundAsync(moderateSoundId).then(async () => {
+        dispatch(removeModerateSound(moderateSoundId));
+      });
+    });
+  };
+};
+
+// ---- Storage ---- //
+
+export const loadModerateSoundUrl = (moderateSoundId: string): ThunkResult<void> => {
+  return async (dispatch, getState) => {
+    if (moderateSoundId === "") return;
+
+    if (!(moderateSoundId in getState().moderateSounds.moderateSounds)) {
+      await getModerateSoundURLFromStorageAsync(moderateSoundId)
+        .then((url) => {
+          if (url) {
+            dispatch(
+              updateModerateSound({
+                id: moderateSoundId,
+                data: {
+                  downloadURL: url,
+                },
+              })
+            );
+          }
+        })
+        .catch(() => {
+          console.error("ロードに失敗 moderateSoundId:", moderateSoundId);
+        });
+    }
+  };
+};
+
+export default moderateSoundsSlice.reducer;

--- a/src/services/ModerateSounds/SOperator/SOperator.ts
+++ b/src/services/ModerateSounds/SOperator/SOperator.ts
@@ -43,7 +43,9 @@ export const getModerateSoundsAsync = async () => {
       });
       return moderateSounds;
     })
-    .catch(() => {});
+    .catch((e) => {
+      console.error(e, "ModerateSoundリストの取得に失敗しました");
+    });
 };
 
 export const getModerateSoundAsync = async (moderateSoundId: string) => {
@@ -89,7 +91,7 @@ export const uploadModerateSoundURLFromStorageAsync = async (
   data: UploadModerateSoundFile
 ) => {
   if (moderateSoundId === "") return;
-  return uploadBytes(ModerateSoundFilesRef(), data);
+  return uploadBytes(ref(ModerateSoundFilesRef(), moderateSoundId), data);
 };
 
 export const removeModerateSoundFromStorageAsync = async (moderateSoundId: string) => {

--- a/src/services/ModerateSounds/SOperator/SOperator.ts
+++ b/src/services/ModerateSounds/SOperator/SOperator.ts
@@ -1,0 +1,98 @@
+import { deleteDoc, doc, FirestoreDataConverter, getDoc, getDocs, setDoc, updateDoc } from "firebase/firestore";
+import { deleteObject, getDownloadURL, ref, uploadBytes } from "firebase/storage";
+import { Dict } from "Types/Utils";
+import {
+  isModerateSound,
+  ModerateSound,
+  ModerateSoundAddedToFirestore,
+  ModerateSoundFilesRef,
+  ModerateSoundsRef,
+  ModerateSoundUpdatedToFirestore,
+  UploadModerateSoundFile,
+} from "../ModerateSounds";
+
+// ---- Firestore ---- //
+
+const moderateSoundConverter: FirestoreDataConverter<ModerateSound> = {
+  toFirestore: (moderateSound) => {
+    return {
+      ...moderateSound,
+    };
+  },
+  fromFirestore: (snapshot, options) => {
+    const data = snapshot.data(options);
+    const moderateSound = {
+      ...data,
+    };
+    if (!isModerateSound(moderateSound)) throw Error("firebaseの進行サウンド情報が不正");
+    return moderateSound;
+  },
+};
+
+export const getModerateSoundsAsync = async () => {
+  return await getDocs(ModerateSoundsRef().withConverter(moderateSoundConverter))
+    .then((ss) => {
+      const moderateSounds: Dict<ModerateSound> = {};
+      ss.forEach((doc) => {
+        const data = doc.data();
+        moderateSounds[doc.id] = {
+          name: data.name,
+          type: data.type,
+          filename: data.filename,
+        };
+      });
+      return moderateSounds;
+    })
+    .catch(() => {});
+};
+
+export const getModerateSoundAsync = async (moderateSoundId: string) => {
+  if (moderateSoundId === "") return;
+
+  const ss = await getDoc(doc(ModerateSoundsRef(), moderateSoundId).withConverter(moderateSoundConverter));
+
+  if (!ss.exists()) return;
+
+  return ss.data();
+};
+
+export const setModerateSoundAsync = async (
+  moderateSoundId: string,
+  moderateSoundData: ModerateSoundAddedToFirestore
+) => {
+  if (moderateSoundId === "") return;
+  await setDoc(doc(ModerateSoundsRef(), moderateSoundId).withConverter(moderateSoundConverter), moderateSoundData);
+};
+
+export const updateModerateSoundAsync = async (
+  moderateSoundId: string,
+  moderateSoundData: ModerateSoundUpdatedToFirestore
+) => {
+  if (moderateSoundId === "") return;
+  await updateDoc(doc(ModerateSoundsRef(), moderateSoundId).withConverter(moderateSoundConverter), moderateSoundData);
+};
+
+export const removeModerateSoundAsync = async (moderateSoundId: string) => {
+  if (moderateSoundId === "") return;
+  await deleteDoc(doc(ModerateSoundsRef(), moderateSoundId).withConverter(moderateSoundConverter));
+};
+
+// ---- Storage ---- //
+
+export const getModerateSoundURLFromStorageAsync = async (moderateSoundId: string) => {
+  if (moderateSoundId === "") return;
+  return getDownloadURL(ref(ModerateSoundFilesRef(), moderateSoundId));
+};
+
+export const uploadModerateSoundURLFromStorageAsync = async (
+  moderateSoundId: string,
+  data: UploadModerateSoundFile
+) => {
+  if (moderateSoundId === "") return;
+  return uploadBytes(ModerateSoundFilesRef(), data);
+};
+
+export const removeModerateSoundFromStorageAsync = async (moderateSoundId: string) => {
+  if (moderateSoundId === "") return;
+  return deleteObject(ref(ModerateSoundFilesRef(), moderateSoundId));
+};

--- a/src/services/RealtimeGrandPrix/DBOperator/DBOperator.ts
+++ b/src/services/RealtimeGrandPrix/DBOperator/DBOperator.ts
@@ -1,4 +1,5 @@
 import { child, get, push, set, update } from "firebase/database";
+import { PRESENTATION_TIME } from "styles/constants/constants";
 import { Dict } from "Types/Utils";
 import {
   ActionsRef,
@@ -53,7 +54,7 @@ export const getGrandPrixAsync = async (grandPrixId: string) => {
     enabled: data.enabled,
     currentPresenterId: data.currentPresenterId,
     nextPresenterId: data.nextPresenterId,
-    presentationTime: data.presentationTime || new Date(600000),
+    presentationTime: data.presentationTime || new Date(PRESENTATION_TIME),
     startTime: data.startTime,
   });
 
@@ -205,7 +206,6 @@ export const removeMessageReactionsAsync = async (grandPrixId: string, presenter
 
 export const addBoostActionAsync = async (grandPrixId: string, presenterId: string, boostAction: BoostAction) => {
   if (grandPrixId == "" || presenterId == "") return;
-  console.log(grandPrixId, presenterId, boostAction, BoostActionsRef(grandPrixId, presenterId).toString());
   await push(BoostActionsRef(grandPrixId, presenterId), BoostActionConverter.toDB(boostAction));
 };
 

--- a/src/services/RealtimeGrandPrix/RealtimeGrandPrix.ts
+++ b/src/services/RealtimeGrandPrix/RealtimeGrandPrix.ts
@@ -4,6 +4,7 @@ import "firebase_config";
 import { addChild, moveChild, removeChild } from "services/Utils/realtimeDatabase/InsertSortOfKeys";
 import { DBConverter, ListPayload, ValuePayload } from "services/Utils/realtimeDatabase/RealtimeDBListener";
 import { nullable } from "services/Utils/Types";
+import { PRESENTATION_TIME } from "styles/constants/constants";
 
 export const RootRef = () => ref(getDatabase(), "/GrandPrixApp");
 export const GrandPrixesRef = () => child(RootRef(), "grandPrixes");
@@ -42,7 +43,7 @@ export const RTGrandPrixConverter: DBConverter<RTGrandPrix, RTGrandPrixOnDB> = {
     keys.forEach((key) => {
       if (data[key]) {
         if (key == "presentationTime") {
-          const time = data[key] || new Date(600000);
+          const time = data[key] || new Date(PRESENTATION_TIME);
           result[key] = time.toISOString();
         } else if (key == "startTime") {
           result[key] = data[key]?.toISOString();
@@ -60,7 +61,7 @@ export const RTGrandPrixConverter: DBConverter<RTGrandPrix, RTGrandPrixOnDB> = {
   fromDB: (data) => {
     return {
       ...data,
-      presentationTime: data.presentationTime ? new Date(data.presentationTime) : new Date(600000),
+      presentationTime: data.presentationTime ? new Date(data.presentationTime) : new Date(PRESENTATION_TIME),
       startTime: data.startTime ? new Date(data.startTime) : undefined,
     };
   },

--- a/src/services/StampResources/StampResources.ts
+++ b/src/services/StampResources/StampResources.ts
@@ -53,7 +53,7 @@ export const loadImageUrl = (stampId: string): ThunkResult<void> => {
           }
         })
         .catch(() => {
-          console.log("ロードに失敗 stampId:", stampId);
+          console.error("ロードに失敗 stampId:", stampId);
         });
     }
   };
@@ -75,7 +75,7 @@ export const loadSoundUrl = (stampId: string): ThunkResult<void> => {
           }
         })
         .catch(() => {
-          console.log("ロードに失敗 stampId:", stampId);
+          console.error("ロードに失敗 stampId:", stampId);
         });
     }
   };

--- a/src/services/User/User.ts
+++ b/src/services/User/User.ts
@@ -91,6 +91,7 @@ const userSlice = createSlice({
      */
     signOut: (state) => {
       Object.assign(state, initialState);
+      state.loading = false;
     },
   },
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -8,7 +8,9 @@ import stampsReducer, { StampsState } from "services/Stamps/Stamps";
 import stampTypesReducer, { StampTypesState } from "services/StampTypes/StampTypes";
 import grandPrixesReducer, { GrandPrixesState } from "services/GrandPrixes/GrandPrixes";
 import StampResourcesReducer, { StampResourcesState } from "services/StampResources/StampResources";
+
 import usersReducer, { UsersState } from "services/Users/Users";
+import moderateSoundsReducer, { ModerateSoundsState } from "services/ModerateSounds/ModerateSounds";
 
 export type RootState = {
   user: UserState;
@@ -19,6 +21,7 @@ export type RootState = {
   stampTypes: StampTypesState;
   grandPrixes: GrandPrixesState;
   stampResources: StampResourcesState;
+  moderateSounds: ModerateSoundsState;
 };
 
 export const store = configureStore({
@@ -31,6 +34,7 @@ export const store = configureStore({
     stampTypes: stampTypesReducer,
     grandPrixes: grandPrixesReducer,
     stampResources: StampResourcesReducer,
+    moderateSounds: moderateSoundsReducer,
   },
   middleware: [thunk],
 });

--- a/src/styles/constants/constants.ts
+++ b/src/styles/constants/constants.ts
@@ -59,3 +59,5 @@ export const Z_INDEX = {
   /** 最大値 */
   MAX: 9999,
 };
+
+export const PRESENTATION_TIME = 6 * 60 * 1000; // 25分


### PR DESCRIPTION
## チケットリンク
- #98 
- #67 

## やったこと
- プレゼン進行ボイスサービスを実装
  - ステータスはFirestoreで、音声データはStorageで管理
- プレゼン進行ボイスの編集機能を実装
  - adminで編集可能
  - 音声もアップロード可能
- Live画面でプレゼンを進行するボイスが流れるように実装
  - 開始時
  - 終了５分前
  - 終了時
- #67 を修正
  - ログアウト時のステータスにバグがあった
- SideMenuのリンクを修正
  - 先頭スラッシュだけだと同じページ名だとactiveになるらしい
  - 最後にもスラッシュ付けた方がいいかも

## やらなかったこと
- プレゼン進行ボイスの編集機能にて１つバグが残っている
  - 編集の初期状態でデータを持っていないため、再編集時にファイルを選択しないと空データが保存されてしまう
  - チケット化： #104

## レビュー項目
- [ ] プレゼン進行ボイスを管理画面で編集できる
- [ ] ライブ画面にて指定時間にプレゼン進行ボイスが流れる

## 備考
- 特に無し
