### PR TITLE
GrandPrixListを実装

### DIFF
--- a/src/components/GrandprixCard/GrandprixCardStyle.tsx
+++ b/src/components/GrandprixCard/GrandprixCardStyle.tsx
@@ -33,6 +33,8 @@ const defaultStyle = css`
   }
 
   .grandprixcard_main {
+    display: flex;
+    flex-direction: column;
     max-width: 100%;
 
     .grandprixcard_title,
@@ -41,6 +43,7 @@ const defaultStyle = css`
       line-height: 150%;
       white-space: nowrap;
       text-overflow: ellipsis;
+      overflow: hidden;
     }
 
     .grandprixcard_title {

--- a/src/pages/GrandPrixList/GrandPrixList.tsx
+++ b/src/pages/GrandPrixList/GrandPrixList.tsx
@@ -1,7 +1,10 @@
-import { WithHeaderFooter } from "components/Layout/WithHeaderFooter/WithHeaderFooter";
 import React from "react";
 import { Link } from "react-router-dom";
+import { WithHeaderFooter } from "components/Layout/WithHeaderFooter/WithHeaderFooter";
 import { useGrandPrixListState } from "./hooks/useGrandPrixListState";
+import { TileBack } from "components/TileBack/TileBack";
+import { GrandprixCard } from "components/GrandprixCard/GrandprixCard";
+import { GrandPrixListStyle } from "./GrandPrixListStyle";
 
 type Props = {};
 
@@ -9,32 +12,22 @@ export const GrandPrixList: React.FC<Props> = () => {
   const { grandPrixes, sortedKeys } = useGrandPrixListState();
   return (
     <WithHeaderFooter>
-      <h1>グランプリ</h1>
-      {sortedKeys.map((key) => (
-        <ul key={key}>
-          <li>
-            副題：
-            {grandPrixes[key].subtitle}
-          </li>
-          <li>
-            ナンバリング：
-            {grandPrixes[key].number}
-          </li>
-          <li>
-            開催日：
-            {grandPrixes[key].eventDate.toString()}
-          </li>
-          <li>
-            ステータス：
-            {grandPrixes[key].status}
-          </li>
-          <li>
-            説明：
-            <pre>{grandPrixes[key].description}</pre>
-          </li>
-          <Link to={"/grandprix/" + key}>グランプリトップ</Link>
-        </ul>
-      ))}
+      <TileBack type="default" title="プロジェクト一覧" useHeadPadding={true}>
+        <GrandPrixListStyle>
+          <div className="grandprixlist_wrapper">
+            {sortedKeys.map((key) => (
+              <Link key={key} to={`/grandprix/${key}/`} className="grandprixlist_card">
+                <GrandprixCard
+                  title={`第${grandPrixes[key].number}回  遼平会`}
+                  subTitle={grandPrixes[key].subtitle}
+                  date={grandPrixes[key].eventDate}
+                  status={grandPrixes[key].status}
+                />
+              </Link>
+            ))}
+          </div>
+        </GrandPrixListStyle>
+      </TileBack>
     </WithHeaderFooter>
   );
 };

--- a/src/pages/GrandPrixList/GrandPrixListStyle.tsx
+++ b/src/pages/GrandPrixList/GrandPrixListStyle.tsx
@@ -1,0 +1,28 @@
+import styled from "styled-components";
+import { FlexGap } from "styles/Utils/FlexGap";
+
+export const GrandPrixListStyle = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  min-height: 100vh;
+  max-width: 100%;
+  padding-bottom: 48px;
+
+  .grandprixlist_wrapper {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-content: flex-start;
+    justify-content: space-around;
+    ${FlexGap({ gap: "64px", direction: "row" })}
+    padding: 24px 64px;
+    max-width: 1500px;
+    flex-shrink: 1;
+    min-width: 0;
+  }
+
+  .grandprixlist_card {
+    text-decoration: none;
+  }
+`;


### PR DESCRIPTION
## チケットリンク
- #61 

## やったこと
- GrandPrixListを実装
- GrandPrixCardを修正
- スクショ
![image](https://user-images.githubusercontent.com/26971566/202263740-8db747cf-b115-4fb3-89d3-fdc8f3aa762d.png)


## やらなかったこと
- 若干スタイルが気に入っていない．左揃えで並べつつ中央に配置するにはどうすればいいのだろうか．
- もっと見るボタン（ページング）は実装していないし別に要らない気がする

## レビュー項目
- [ ] グランプリ一覧画面のデザインが確認できること

## 備考
- 特に無し
