### PR TITLE
グランプリのリアクションを集計するロジックを実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { UserSetting } from "pages/UserSetting/UserSetting";
 import { UserTop } from "pages/UserTop/UserTop";
 import React from "react";
 import { HashRouter, Route, Routes } from "react-router-dom";
+import { Result } from "pages/Result/Result";
 
 type Props = {};
 
@@ -38,6 +39,7 @@ export const App: React.FC<Props> = () => {
         <Route path="/grandprix/:id" element={<GrandPrix />} />
         <Route path="/reaction/:id" element={<PrivateRoute component={Reaction} />} />
         <Route path="/live/:id" element={<PrivateRoute component={Live} />} />
+        <Route path="/grandprix/:id/result" element={<PrivateRoute component={Result} />} />
         <Route path="/idaina-okotoba" element={<IdaiNaOkotoba />} />
         <Route path="/admin" element={<AdminRoute component={AdminTop} />} />
         <Route path="/admin/gpcontroller/:id" element={<AdminRoute component={GrandPrixController} />} />

--- a/src/hooks/ReactionStats/useReactionStats.ts
+++ b/src/hooks/ReactionStats/useReactionStats.ts
@@ -1,0 +1,156 @@
+import { useEffect, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { ActionList, BoostAction, HotItem, Reaction } from "services/RealtimeGrandPrix/RealtimeGrandPrix";
+import { reloadAllActionsAsync } from "services/RealtimeGrandPrix/StatsGrandPrix";
+import { Stamp } from "services/Stamps/Stamps";
+import { StampType } from "services/StampTypes/StampTypes";
+import { RootState } from "store";
+import { COLLVO_POINT } from "styles/constants/constants";
+import { Dict } from "Types/Utils";
+
+type ReactionCounts = {
+  good: {
+    reaction: number;
+    boost: number;
+  };
+  psycho: {
+    reaction: number;
+    boost: number;
+  };
+  wait: {
+    reaction: number;
+    boost: number;
+  };
+};
+
+type ReactionStat = {
+  presenterId: string;
+  stat?: {
+    count: ReactionCounts;
+    total: number;
+  };
+};
+
+type Reactions = ActionList<HotItem<Reaction>>;
+
+const countReactions = (
+  reactions: Reactions,
+  boostActions: ActionList<HotItem<BoostAction>>,
+  stamps: Dict<Stamp>,
+  stampTypes: Dict<StampType>
+) => {
+  return reactions.sortedKey.reduce<ReactionCounts>(
+    (reactionStat, value) => {
+      const reaction = reactions.data[value];
+      const stamp = stamps[reaction.stampId];
+      if (!stamp) throw Error("スタンプのデータが存在しないため、順位を計算できませんでした。");
+
+      const stampType = stampTypes[stamp.typeId];
+      if (!stampType) throw Error("スタンプタイプのデータが存在しないため、順位を計算できませんでした。");
+
+      let isBoost = false;
+      boostActions.sortedKey.forEach((bid) => {
+        const boostAction = boostActions.data[bid];
+        const boostStart = boostAction.sendAt;
+        const boostEnd = new Date(boostStart.getTime() + COLLVO_POINT.BOOST_ACTION.DURATION * 1000);
+        if (boostStart < reaction.sendAt && reaction.sendAt < boostEnd) {
+          isBoost = true;
+          return;
+        }
+      });
+
+      const count = isBoost ? COLLVO_POINT.BOOST_ACTION.CP_MAG : 1;
+
+      if (stampType.name === "good") {
+        reactionStat.good = {
+          reaction: reactionStat.good.reaction + count,
+          boost: reactionStat.good.boost + (isBoost ? count : 0),
+        };
+      } else if (stampType.name === "psycho") {
+        reactionStat.psycho = {
+          reaction: reactionStat.psycho.reaction + count,
+          boost: reactionStat.psycho.boost + (isBoost ? count : 0),
+        };
+      } else if (stampType.name === "wait") {
+        reactionStat.wait = {
+          reaction: reactionStat.wait.reaction + count,
+          boost: reactionStat.wait.boost + (isBoost ? count : 0),
+        };
+      }
+
+      return reactionStat;
+    },
+    {
+      good: {
+        reaction: 0,
+        boost: 0,
+      },
+      psycho: {
+        reaction: 0,
+        boost: 0,
+      },
+      wait: {
+        reaction: 0,
+        boost: 0,
+      },
+    }
+  );
+};
+
+const combineReactions = (a: Reactions, b: Reactions): Reactions => {
+  return {
+    sortedKey: a.sortedKey.concat(b.sortedKey),
+    data: {
+      ...a.data,
+      ...b.data,
+    },
+  };
+};
+
+export const useReactionStats = (grandPrixId: string) => {
+  const { stampTypes } = useSelector((state: RootState) => state.stampTypes);
+  const { stamps } = useSelector((state: RootState) => state.stamps);
+
+  const statsGrandPrix = useSelector((state: RootState) => state.statsGrandPrix);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(reloadAllActionsAsync(grandPrixId));
+  }, [grandPrixId]);
+
+  const reactionStats = useMemo<ReactionStat[] | undefined>(() => {
+    if (!statsGrandPrix[grandPrixId] || !stamps || !stampTypes) return undefined;
+    const stats = Object.keys(statsGrandPrix[grandPrixId])
+      .map((pid) => {
+        const plainReactions = statsGrandPrix[grandPrixId][pid].plainReactions;
+        const messageReactions = statsGrandPrix[grandPrixId][pid].messageReactions;
+        const boostActions = statsGrandPrix[grandPrixId][pid].boostActions;
+
+        const reactions = combineReactions(plainReactions, messageReactions);
+        try {
+          const stat = countReactions(reactions, boostActions, stamps, stampTypes);
+
+          return {
+            presenterId: pid,
+            stat: {
+              count: stat,
+              total: stat.good.reaction + stat.psycho.reaction + stat.wait.reaction,
+            },
+          };
+        } catch (e) {
+          console.error(e);
+          return {
+            presenterId: pid,
+          };
+        }
+      })
+      .filter((e) => e);
+
+    return stats;
+  }, [statsGrandPrix, stamps, stampTypes, grandPrixId]);
+
+  return {
+    /** 集計されたリアクション数を返す */
+    reactionStats,
+  };
+};

--- a/src/pages/Admin/GrandPrixController/GrandPrixController.tsx
+++ b/src/pages/Admin/GrandPrixController/GrandPrixController.tsx
@@ -109,6 +109,9 @@ export const GrandPrixController: React.FC<Props> = () => {
             CPを配布する！
           </button>
         </li>
+        <li>
+          <Link to={`/grandprix/${grandPrixId}/result`}>結果発表ページ</Link>
+        </li>
       </ul>
     </WithHeaderFooter>
   );

--- a/src/pages/Result/Result.tsx
+++ b/src/pages/Result/Result.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { useResultState } from "./hooks/useResultState";
+import { ResultStyle } from "./ResultStyle";
+
+type Props = {};
+
+export const Result: React.FC<Props> = () => {
+  const { id } = useParams();
+  const { sortedReactionStats } = useResultState(id || "");
+
+  return (
+    <ResultStyle>
+      <ul>
+        {sortedReactionStats &&
+          sortedReactionStats.map((sortedReactionStat) => (
+            <li key={sortedReactionStat.presenterId}>
+              いいね！：{sortedReactionStat.stat?.count.good.reaction}回<br />
+              いいね！（ブースト）：{sortedReactionStat.stat?.count.good.boost}回<br />
+              サイコです！：{sortedReactionStat.stat?.count.psycho.reaction}回<br />
+              サイコです！（ブースト）：{sortedReactionStat.stat?.count.psycho.boost}回<br />
+              ちょっとまて！：{sortedReactionStat.stat?.count.wait.reaction}回<br />
+              ちょっとまて！（ブースト）：{sortedReactionStat.stat?.count.wait.boost}回<br />
+              合計：{sortedReactionStat.stat?.total}
+            </li>
+          ))}
+      </ul>
+    </ResultStyle>
+  );
+};

--- a/src/pages/Result/ResultStyle.tsx
+++ b/src/pages/Result/ResultStyle.tsx
@@ -1,0 +1,3 @@
+import styled from "styled-components";
+
+export const ResultStyle = styled.div``;

--- a/src/pages/Result/hooks/useResultState.ts
+++ b/src/pages/Result/hooks/useResultState.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+import { useReactionStats } from "hooks/ReactionStats/useReactionStats";
+
+export const useResultState = (grandPrixId: string) => {
+  const { reactionStats } = useReactionStats(grandPrixId);
+
+  const sortedReactionStats = useMemo(() => {
+    return reactionStats?.sort((a, b) => {
+      if (!a.stat) return 1;
+      if (!b.stat) return -1;
+      return a.stat.total - b.stat.total;
+    });
+  }, [reactionStats]);
+
+  return {
+    sortedReactionStats,
+  };
+};


### PR DESCRIPTION
## チケットリンク
- #115 

## やったこと
- グランプリのリアクションを集計するロジックを実装
- グランプリ結果ページの作成

## やらなかったこと
- デバッグが少し甘めです

## レビュー項目
- [ ] `/grandprix/:id/result`にアクセスすると、結果が表示される．デフォルトの値にはエラー値（存在しないスタンプID）が存在するため、集計結果が正しく表示されない．

## 備考
- 特になし
