### PR TITLE
[fix] 画像をblobでローカルに保持するように設定

### DIFF
--- a/src/Utils/funcs.ts
+++ b/src/Utils/funcs.ts
@@ -86,5 +86,5 @@ export const convertToDataUrlFromBlob = async (blob: Blob): Promise<string> => {
   return await new Promise((resolve) => {
     const dataURL = window.URL.createObjectURL(blob);
     resolve(dataURL);
-  })
-}
+  });
+};

--- a/src/Utils/funcs.ts
+++ b/src/Utils/funcs.ts
@@ -76,3 +76,15 @@ export const randomChoice = <T>(array: T[]) => {
   if (array.length === 0) return undefined;
   return array[Math.floor(Math.random() * array.length)];
 };
+
+/**
+ * BlobからDataURLへ変換する
+ * @param blob Blobオブジェクト
+ * @returns BlobオブジェクトのデータURL
+ */
+export const convertToDataUrlFromBlob = async (blob: Blob): Promise<string> => {
+  return await new Promise((resolve) => {
+    const dataURL = window.URL.createObjectURL(blob);
+    resolve(dataURL);
+  })
+}

--- a/src/components/BlinkPlainReaction/hooks/useBlinkPlainReactionState.ts
+++ b/src/components/BlinkPlainReaction/hooks/useBlinkPlainReactionState.ts
@@ -1,7 +1,6 @@
 import { Stamp } from "components/Stamp/Stamp";
 import { usePlainReactionSerializer } from "hooks/RealtimeGrandPrix/serializers/usePlainReactionSerializer";
 import { ComponentProps, useEffect, useMemo, useState } from "react";
-import { useImage } from "react-image";
 
 export type IResponse = {
   stampProps: ComponentProps<typeof Stamp>;
@@ -14,10 +13,6 @@ export const useBlinkPlainReactionState = (
   quiteCallback?: () => void
 ): IResponse => {
   const { serializedPlainReaction } = usePlainReactionSerializer(plainReactionId);
-  const { src, isLoading, error } = useImage({
-    srcList: [serializedPlainReaction?.stamp?.imageDataUrl || ""],
-    useSuspense: false,
-  });
   const [animate, setAnimate] = useState(false);
   const sound = useMemo(
     () => new Audio(serializedPlainReaction?.stamp?.soundDataUrl),
@@ -25,19 +20,19 @@ export const useBlinkPlainReactionState = (
   );
 
   useEffect(() => {
-    if (!animate && (!isLoading || error)) {
+    if (!animate && !serializedPlainReaction?.stamp?.loadingResource) {
       if (playSoundEffect) sound.play();
       setAnimate(true);
       setTimeout(() => {
         if (quiteCallback) quiteCallback();
       }, 3000);
     }
-  }, [isLoading, error]);
+  }, [serializedPlainReaction?.stamp?.loadingResource]);
 
   return {
     stampProps: {
       stampName: serializedPlainReaction?.stamp?.name,
-      stampUrl: src,
+      stampUrl: serializedPlainReaction?.stamp?.imageDataUrl,
     },
     animate,
   };

--- a/src/components/ReactionMeter/hooks/useReactionMeterState.ts
+++ b/src/components/ReactionMeter/hooks/useReactionMeterState.ts
@@ -36,7 +36,7 @@ export const useReactionMeterState = (): IResponse => {
       if (!plainReactionId) return;
 
       // 準備
-      const nowWithOffset = new Date(new Date().getTime() - 60000);
+      const nowWithOffset = new Date(new Date().getTime() - 3 * 1000); // 3s前まで
       const plainReaction = plainReactions.data[plainReactionId];
 
       // 表示済み・現在時刻より前過ぎる場合は表示しない

--- a/src/hooks/Admin/StampResources/useEditableStampImage.ts
+++ b/src/hooks/Admin/StampResources/useEditableStampImage.ts
@@ -2,10 +2,10 @@ import { ref, StorageError, UploadMetadata, UploadTaskSnapshot } from "firebase/
 import { useStampImage } from "hooks/StampResources/useStampImage";
 import { useUploadToStorage } from "hooks/Storage/useUploadToStorage";
 import { removeStampImageFromStorageAsync } from "services/StampResources/SOperator/SOperator";
-import { ImagesRef } from "services/StampResources/StampResources";
+import { ImagesRef, StampResource } from "services/StampResources/StampResources";
 
 export type IResponse = {
-  urls: { [key: string]: string };
+  resources: { [key: string]: StampResource };
   loadUrl: (stampId: string) => void;
   uploader: {
     snapShot: UploadTaskSnapshot | undefined;
@@ -19,7 +19,7 @@ export type IResponse = {
 };
 
 export const useEditableStampImage = (): IResponse => {
-  const { urls, loadUrl } = useStampImage();
+  const { resources, loadUrl } = useStampImage();
   const imageUploader = useUploadToStorage();
 
   const _upload = (stampId: string, data: Blob | Uint8Array | ArrayBuffer, metadata?: UploadMetadata) => {
@@ -33,8 +33,8 @@ export const useEditableStampImage = (): IResponse => {
   };
 
   return {
-    urls: urls,
-    loadUrl: loadUrl,
+    resources,
+    loadUrl,
     uploader: {
       ...imageUploader,
       upload: _upload,

--- a/src/hooks/Admin/StampResources/useEditableStampSound.ts
+++ b/src/hooks/Admin/StampResources/useEditableStampSound.ts
@@ -2,10 +2,10 @@ import { ref, StorageError, UploadMetadata, UploadTaskSnapshot } from "firebase/
 import { useStampSound } from "hooks/StampResources/useStampSound";
 import { useUploadToStorage } from "hooks/Storage/useUploadToStorage";
 import { removeStampSoundFromStorageAsync } from "services/StampResources/SOperator/SOperator";
-import { SoundsRef } from "services/StampResources/StampResources";
+import { SoundsRef, StampResource } from "services/StampResources/StampResources";
 
 export type IResponse = {
-  urls: { [key: string]: string };
+  resources: { [key: string]: StampResource };
   loadUrl: (stampId: string) => void;
   uploader: {
     snapShot: UploadTaskSnapshot | undefined;
@@ -19,7 +19,7 @@ export type IResponse = {
 };
 
 export const useEditableStampSound = (): IResponse => {
-  const { urls, loadUrl } = useStampSound();
+  const { resources, loadUrl } = useStampSound();
   const soundUploader = useUploadToStorage();
 
   const _upload = (stampId: string, data: Blob | Uint8Array | ArrayBuffer, metadata?: UploadMetadata) => {
@@ -33,8 +33,8 @@ export const useEditableStampSound = (): IResponse => {
   };
 
   return {
-    urls: urls,
-    loadUrl: loadUrl,
+    resources,
+    loadUrl,
     uploader: {
       ...soundUploader,
       upload: _upload,

--- a/src/hooks/ModerateSoundResources/useModerateSound.ts
+++ b/src/hooks/ModerateSoundResources/useModerateSound.ts
@@ -31,9 +31,9 @@ export const useModerateSound = (): IResponse => {
     [moderateSounds]
   );
 
-  const loadUrl = async (moderateSoundId: string) => {
+  const loadUrl = useCallback(async (moderateSoundId: string) => {
     await dispatch(loadModerateSoundUrl(moderateSoundId));
-  };
+  }, []);
 
   return {
     moderateSounds,

--- a/src/hooks/StampResources/useStampImage.ts
+++ b/src/hooks/StampResources/useStampImage.ts
@@ -1,22 +1,23 @@
+import { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { loadImageUrl } from "services/StampResources/StampResources";
+import { StampResource, loadImageUrl } from "services/StampResources/StampResources";
 import { RootState } from "store";
 
 export type IResponse = {
-  urls: { [key: string]: string };
+  resources: { [key: string]: StampResource };
   loadUrl: (stampId: string) => void;
 };
 
 export const useStampImage = (): IResponse => {
-  const { imageUrls } = useSelector((state: RootState) => state.stampResources);
+  const { imageResources } = useSelector((state: RootState) => state.stampResources);
   const dispatch = useDispatch();
 
-  const _loadUrl = (stampId: string) => {
+  const loadUrl = useCallback((stampId: string) => {
     dispatch(loadImageUrl(stampId));
-  };
+  }, []);
 
   return {
-    urls: imageUrls,
-    loadUrl: _loadUrl,
+    resources: imageResources,
+    loadUrl,
   };
 };

--- a/src/hooks/StampResources/useStampSound.ts
+++ b/src/hooks/StampResources/useStampSound.ts
@@ -1,22 +1,23 @@
+import { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { loadSoundUrl } from "services/StampResources/StampResources";
+import { StampResource, loadSoundUrl } from "services/StampResources/StampResources";
 import { RootState } from "store";
 
 export type IResponse = {
-  urls: { [key: string]: string };
+  resources: { [key: string]: StampResource };
   loadUrl: (stampId: string) => void;
 };
 
 export const useStampSound = (): IResponse => {
-  const { soundUrls } = useSelector((state: RootState) => state.stampResources);
+  const { soundResources } = useSelector((state: RootState) => state.stampResources);
   const dispatch = useDispatch();
 
-  const _loadUrl = (stampId: string) => {
+  const loadUrl = useCallback((stampId: string) => {
     dispatch(loadSoundUrl(stampId));
-  };
+  }, []);
 
   return {
-    urls: soundUrls,
-    loadUrl: _loadUrl,
+    resources: soundResources,
+    loadUrl,
   };
 };

--- a/src/pages/Admin/Top/components/EditableModerateSound/hooks/useEditableModerateSoundState.ts
+++ b/src/pages/Admin/Top/components/EditableModerateSound/hooks/useEditableModerateSoundState.ts
@@ -82,16 +82,17 @@ export const useEditableModerateSoundState = (
   );
 
   useEffect(() => {
-    loadUrl(moderateSoundId);
+    if(!isNew) loadUrl(moderateSoundId);
     setSoundDataArray(undefined);
   }, []);
 
   useEffect(() => {
-    const downloadURL = moderateSounds[moderateSoundId]?.downloadURL;
-    if (downloadURL) {
-      setSoundDataURL(downloadURL);
+    const dataUrl = moderateSounds[moderateSoundId]?.resource?.dataUrl;
+
+    if (dataUrl) {
+      setSoundDataURL(dataUrl);
     }
-  }, [moderateSounds[moderateSoundId]?.downloadURL]);
+  }, [moderateSounds[moderateSoundId]?.resource]);
 
   useEffect(() => {
     soundFileReader.asUrl.onload = (reader) => {

--- a/src/pages/Admin/Top/components/EditableModerateSound/hooks/useEditableModerateSoundState.ts
+++ b/src/pages/Admin/Top/components/EditableModerateSound/hooks/useEditableModerateSoundState.ts
@@ -82,7 +82,7 @@ export const useEditableModerateSoundState = (
   );
 
   useEffect(() => {
-    if(!isNew) loadUrl(moderateSoundId);
+    if (!isNew) loadUrl(moderateSoundId);
     setSoundDataArray(undefined);
   }, []);
 

--- a/src/pages/Admin/Top/components/EditableStampInfo/hooks/useEditableStampInfoState.ts
+++ b/src/pages/Admin/Top/components/EditableStampInfo/hooks/useEditableStampInfoState.ts
@@ -54,7 +54,7 @@ export const useEditableStampInfoState = (
 ): IResponse => {
   const stampTypes = useSelector((state: RootState) => state.stampTypes.stampTypes);
   const [uploadStatus, setUploadStatus] = useState<UploadStatusType>(UploadStatus.standBy);
-  const { urls: imageUrls, loadUrl: loadImageUrl, uploader: imageUploader, removeImage } = useEditableStampImage();
+  const { resources: imageResources, loadUrl: loadImageUrl, uploader: imageUploader, removeImage } = useEditableStampImage();
   const [imageFileReader] = useState({
     asUrl: new FileReader(),
     asArray: new FileReader(),
@@ -62,7 +62,7 @@ export const useEditableStampInfoState = (
   const [imageIsUploading, setImageIsUploading] = useState(false);
   const [imageDataURL, setImageDataURL] = useState("");
   const [imageDataArray, setImageDataArray] = useState<ArrayBuffer>();
-  const { urls: soundUrls, loadUrl: loadSoundUrl, uploader: soundUploader, removeSound } = useEditableStampSound();
+  const { resources: soundResources, loadUrl: loadSoundUrl, uploader: soundUploader, removeSound } = useEditableStampSound();
   const [soundFileReader] = useState({
     asUrl: new FileReader(),
     asArray: new FileReader(),
@@ -95,26 +95,30 @@ export const useEditableStampInfoState = (
   );
 
   useEffect(() => {
-    loadImageUrl(stampId);
+    if(!isNew) loadImageUrl(stampId);
     setImageDataArray(undefined);
   }, []);
 
   useEffect(() => {
-    if (imageUrls[stampId]) {
-      setImageDataURL(imageUrls[stampId]);
+    const dataUrl = imageResources[stampId]?.dataUrl;
+
+    if (dataUrl) {
+      setImageDataURL(dataUrl);
     }
-  }, [imageUrls[stampId]]);
+  }, [imageResources[stampId]]);
 
   useEffect(() => {
-    loadSoundUrl(stampId);
+    if(!isNew) loadSoundUrl(stampId);
     setSoundDataArray(undefined);
   }, []);
 
   useEffect(() => {
-    if (soundUrls[stampId]) {
-      setSoundDataURL(soundUrls[stampId]);
+    const dataUrl = soundResources[stampId]?.dataUrl;
+
+    if (dataUrl) {
+      setSoundDataURL(dataUrl);
     }
-  }, [soundUrls[stampId]]);
+  }, [soundResources[stampId]]);
 
   useEffect(() => {
     imageFileReader.asUrl.onload = (reader) => {

--- a/src/pages/Admin/Top/components/EditableStampInfo/hooks/useEditableStampInfoState.ts
+++ b/src/pages/Admin/Top/components/EditableStampInfo/hooks/useEditableStampInfoState.ts
@@ -54,7 +54,12 @@ export const useEditableStampInfoState = (
 ): IResponse => {
   const stampTypes = useSelector((state: RootState) => state.stampTypes.stampTypes);
   const [uploadStatus, setUploadStatus] = useState<UploadStatusType>(UploadStatus.standBy);
-  const { resources: imageResources, loadUrl: loadImageUrl, uploader: imageUploader, removeImage } = useEditableStampImage();
+  const {
+    resources: imageResources,
+    loadUrl: loadImageUrl,
+    uploader: imageUploader,
+    removeImage,
+  } = useEditableStampImage();
   const [imageFileReader] = useState({
     asUrl: new FileReader(),
     asArray: new FileReader(),
@@ -62,7 +67,12 @@ export const useEditableStampInfoState = (
   const [imageIsUploading, setImageIsUploading] = useState(false);
   const [imageDataURL, setImageDataURL] = useState("");
   const [imageDataArray, setImageDataArray] = useState<ArrayBuffer>();
-  const { resources: soundResources, loadUrl: loadSoundUrl, uploader: soundUploader, removeSound } = useEditableStampSound();
+  const {
+    resources: soundResources,
+    loadUrl: loadSoundUrl,
+    uploader: soundUploader,
+    removeSound,
+  } = useEditableStampSound();
   const [soundFileReader] = useState({
     asUrl: new FileReader(),
     asArray: new FileReader(),
@@ -95,7 +105,7 @@ export const useEditableStampInfoState = (
   );
 
   useEffect(() => {
-    if(!isNew) loadImageUrl(stampId);
+    if (!isNew) loadImageUrl(stampId);
     setImageDataArray(undefined);
   }, []);
 
@@ -108,7 +118,7 @@ export const useEditableStampInfoState = (
   }, [imageResources[stampId]]);
 
   useEffect(() => {
-    if(!isNew) loadSoundUrl(stampId);
+    if (!isNew) loadSoundUrl(stampId);
     setSoundDataArray(undefined);
   }, []);
 

--- a/src/pages/Live/hooks/useLiveState.ts
+++ b/src/pages/Live/hooks/useLiveState.ts
@@ -85,16 +85,16 @@ export const useLiveState = (): IResponse => {
 
   useEffect(() => {
     const startChoiced = randomChoice(groupedModerateSoundIds.start);
-    if (startChoiced && moderateSounds[startChoiced].downloadURL) {
-      sounds.start.src = moderateSounds[startChoiced].downloadURL || "";
+    if (startChoiced && moderateSounds[startChoiced].resource?.dataUrl) {
+      sounds.start.src = moderateSounds[startChoiced].resource?.dataUrl || "";
     }
     const remain5Choiced = randomChoice(groupedModerateSoundIds.remain5);
-    if (remain5Choiced && moderateSounds[remain5Choiced].downloadURL) {
-      sounds.remain5.src = moderateSounds[remain5Choiced].downloadURL || "";
+    if (remain5Choiced && moderateSounds[remain5Choiced].resource?.dataUrl) {
+      sounds.remain5.src = moderateSounds[remain5Choiced].resource?.dataUrl || "";
     }
     const finishChoiced = randomChoice(groupedModerateSoundIds.finish);
-    if (finishChoiced && moderateSounds[finishChoiced].downloadURL) {
-      sounds.finish.src = moderateSounds[finishChoiced].downloadURL || "";
+    if (finishChoiced && moderateSounds[finishChoiced].resource?.dataUrl) {
+      sounds.finish.src = moderateSounds[finishChoiced].resource?.dataUrl || "";
     }
   }, [moderateSounds, realtimeGrandPrix.grandPrix?.startTime]);
 
@@ -158,7 +158,7 @@ export const useLiveState = (): IResponse => {
       if (!plainReactionId) return;
 
       // 準備
-      const nowWithOffset = new Date(new Date().getTime() - 5000);
+      const nowWithOffset = new Date(new Date().getTime() - 3 * 1000);
       const plainReaction = plainReactions.data[plainReactionId];
 
       // 表示済み・現在時刻より前過ぎる場合は表示しない

--- a/src/services/ModerateSounds/ModerateSounds.ts
+++ b/src/services/ModerateSounds/ModerateSounds.ts
@@ -29,7 +29,7 @@ export type ModerateSoundResource = {
   isDownloading: boolean;
   dataUrl?: string;
   dataSize?: number;
-}
+};
 
 export type UploadModerateSoundFile = Blob | Uint8Array | ArrayBuffer;
 export type ModerateSoundOnDB = Omit<ModerateSound, "resource">;
@@ -221,7 +221,7 @@ export const loadModerateSoundUrl = (moderateSoundId: string): ThunkResult<void>
           data: {
             resource: {
               isDownloading: true,
-            }
+            },
           },
         })
       );
@@ -238,8 +238,8 @@ export const loadModerateSoundUrl = (moderateSoundId: string): ThunkResult<void>
                   resource: {
                     isDownloading: false,
                     dataUrl,
-                    dataSize: dataBlob.size
-                  }
+                    dataSize: dataBlob.size,
+                  },
                 },
               })
             );
@@ -255,9 +255,9 @@ export const loadModerateSoundUrl = (moderateSoundId: string): ThunkResult<void>
             data: {
               resource: {
                 isDownloading: false,
-              }
+              },
             },
-          })
+          });
         });
     }
   };

--- a/src/services/ModerateSounds/SOperator/SOperator.ts
+++ b/src/services/ModerateSounds/SOperator/SOperator.ts
@@ -1,5 +1,5 @@
 import { deleteDoc, doc, FirestoreDataConverter, getDoc, getDocs, setDoc, updateDoc } from "firebase/firestore";
-import { deleteObject, getDownloadURL, ref, uploadBytes } from "firebase/storage";
+import { deleteObject, getBlob, getDownloadURL, ref, uploadBytes } from "firebase/storage";
 import { Dict } from "Types/Utils";
 import {
   isModerateSound,
@@ -85,6 +85,11 @@ export const getModerateSoundURLFromStorageAsync = async (moderateSoundId: strin
   if (moderateSoundId === "") return;
   return getDownloadURL(ref(ModerateSoundFilesRef(), moderateSoundId));
 };
+
+export const getModerateSoundBlobFromStorageAsync = async (moderateSoundId: string) => {
+  if (moderateSoundId === "") return;
+  return getBlob(ref(ModerateSoundFilesRef(), moderateSoundId));
+}
 
 export const uploadModerateSoundURLFromStorageAsync = async (
   moderateSoundId: string,

--- a/src/services/ModerateSounds/SOperator/SOperator.ts
+++ b/src/services/ModerateSounds/SOperator/SOperator.ts
@@ -89,7 +89,7 @@ export const getModerateSoundURLFromStorageAsync = async (moderateSoundId: strin
 export const getModerateSoundBlobFromStorageAsync = async (moderateSoundId: string) => {
   if (moderateSoundId === "") return;
   return getBlob(ref(ModerateSoundFilesRef(), moderateSoundId));
-}
+};
 
 export const uploadModerateSoundURLFromStorageAsync = async (
   moderateSoundId: string,

--- a/src/services/StampResources/SOperator/SOperator.ts
+++ b/src/services/StampResources/SOperator/SOperator.ts
@@ -6,10 +6,10 @@ export const getStampImageURLFromStorageAsync = async (stampId: string) => {
   return getDownloadURL(ref(ImagesRef(), stampId));
 };
 
-export const getStampImageBlobFromStorageAsync = async(stampId: string) => {
+export const getStampImageBlobFromStorageAsync = async (stampId: string) => {
   if (stampId == "") return;
   return getBlob(ref(ImagesRef(), stampId));
-}
+};
 
 export const removeStampImageFromStorageAsync = async (stampId: string) => {
   if (stampId == "") return;
@@ -21,10 +21,10 @@ export const getStampSoundURLFromStorageAsync = async (stampId: string) => {
   return getDownloadURL(ref(SoundsRef(), stampId));
 };
 
-export const getStampSoundBlobFromStorageAsync = async(stampId: string) => {
+export const getStampSoundBlobFromStorageAsync = async (stampId: string) => {
   if (stampId == "") return;
   return getBlob(ref(SoundsRef(), stampId));
-}
+};
 
 export const removeStampSoundFromStorageAsync = async (stampId: string) => {
   if (stampId == "") return;

--- a/src/services/StampResources/SOperator/SOperator.ts
+++ b/src/services/StampResources/SOperator/SOperator.ts
@@ -1,10 +1,15 @@
-import { deleteObject, getDownloadURL, ref } from "firebase/storage";
+import { deleteObject, getBlob, getDownloadURL, ref } from "firebase/storage";
 import { ImagesRef, SoundsRef } from "../StampResources";
 
 export const getStampImageURLFromStorageAsync = async (stampId: string) => {
   if (stampId == "") return;
   return getDownloadURL(ref(ImagesRef(), stampId));
 };
+
+export const getStampImageBlobFromStorageAsync = async(stampId: string) => {
+  if (stampId == "") return;
+  return getBlob(ref(ImagesRef(), stampId));
+}
 
 export const removeStampImageFromStorageAsync = async (stampId: string) => {
   if (stampId == "") return;
@@ -15,6 +20,11 @@ export const getStampSoundURLFromStorageAsync = async (stampId: string) => {
   if (stampId == "") return;
   return getDownloadURL(ref(SoundsRef(), stampId));
 };
+
+export const getStampSoundBlobFromStorageAsync = async(stampId: string) => {
+  if (stampId == "") return;
+  return getBlob(ref(SoundsRef(), stampId));
+}
 
 export const removeStampSoundFromStorageAsync = async (stampId: string) => {
   if (stampId == "") return;

--- a/src/services/StampResources/StampResources.ts
+++ b/src/services/StampResources/StampResources.ts
@@ -67,7 +67,7 @@ export const loadImageUrl = (stampId: string): ThunkResult<void> => {
           id: stampId,
           data: {
             isDownloading: true,
-          }
+          },
         })
       );
       await getStampImageBlobFromStorageAsync(stampId)
@@ -81,7 +81,7 @@ export const loadImageUrl = (stampId: string): ThunkResult<void> => {
                 data: {
                   isDownloading: false,
                   dataUrl,
-                  dataSize: dataBlob.size
+                  dataSize: dataBlob.size,
                 },
               })
             );
@@ -117,7 +117,7 @@ export const loadSoundUrl = (stampId: string): ThunkResult<void> => {
           id: stampId,
           data: {
             isDownloading: true,
-          }
+          },
         })
       );
       await getStampSoundBlobFromStorageAsync(stampId)
@@ -131,8 +131,8 @@ export const loadSoundUrl = (stampId: string): ThunkResult<void> => {
                 data: {
                   isDownloading: false,
                   dataUrl,
-                  dataSize: dataBlob.size
-                }
+                  dataSize: dataBlob.size,
+                },
               })
             );
           }
@@ -143,8 +143,8 @@ export const loadSoundUrl = (stampId: string): ThunkResult<void> => {
             setSoundUrl({
               id: stampId,
               data: {
-                isDownloading: false
-              }
+                isDownloading: false,
+              },
             })
           );
         });

--- a/src/services/StampResources/StampResources.ts
+++ b/src/services/StampResources/StampResources.ts
@@ -1,23 +1,30 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { ref } from "firebase/storage";
 import { getStorage } from "firebase_config";
 import { PayloadWithId, ThunkResult } from "services/Utils/Types";
-import { getStampImageURLFromStorageAsync, getStampSoundURLFromStorageAsync } from "./SOperator/SOperator";
+import { getStampImageBlobFromStorageAsync, getStampSoundBlobFromStorageAsync } from "./SOperator/SOperator";
+import { convertToDataUrlFromBlob } from "Utils/funcs";
 
 export const ImagesRef = () => ref(getStorage(), "StampImage");
 export const SoundsRef = () => ref(getStorage(), "StampSound");
 
-export type StampResourcesState = {
-  imageUrls: { [key: string]: string };
-  soundUrls: { [key: string]: string };
+export type StampResource = {
+  isDownloading: boolean;
+  dataUrl?: string;
+  dataSize?: number;
 };
 
-type ImagePayload = PayloadWithId<string>;
-type SoundPayload = PayloadWithId<string>;
+export type StampResourcesState = {
+  imageResources: { [key: string]: StampResource };
+  soundResources: { [key: string]: StampResource };
+};
+
+type ImagePayload = PayloadWithId<StampResource>;
+type SoundPayload = PayloadWithId<StampResource>;
 
 const initialState: StampResourcesState = {
-  imageUrls: {},
-  soundUrls: {},
+  imageResources: {},
+  soundResources: {},
 };
 
 const stampResourcesSlice = createSlice({
@@ -26,34 +33,70 @@ const stampResourcesSlice = createSlice({
   reducers: {
     setImageUrl: (state, action: ImagePayload) => {
       const { id, data } = action.payload;
-      state.imageUrls[id] = data;
+      state.imageResources[id] = data;
+    },
+    removeImageUrl: (state, action: PayloadAction<string>) => {
+      const id = action.payload;
+      delete state.imageResources[id];
     },
     setSoundUrl: (state, action: SoundPayload) => {
       const { id, data } = action.payload;
-      state.soundUrls[id] = data;
+      state.soundResources[id] = data;
+    },
+    removeSoundUrl: (state, action: PayloadAction<string>) => {
+      const id = action.payload;
+      delete state.soundResources[id];
     },
   },
 });
 
-export const { setImageUrl, setSoundUrl } = stampResourcesSlice.actions;
+export const { setImageUrl, removeImageUrl, setSoundUrl, removeSoundUrl } = stampResourcesSlice.actions;
 
 export const loadImageUrl = (stampId: string): ThunkResult<void> => {
   return async (dispatch, getState) => {
     if (stampId == "") return;
-    if (!(stampId in getState().stampResources.imageUrls)) {
-      await getStampImageURLFromStorageAsync(stampId)
-        .then((url) => {
-          if (url) {
+
+    const imageResource = getState().stampResources.imageResources[stampId];
+
+    // ダウンロード中の場合は弾く
+    if (imageResource && imageResource.isDownloading) return;
+
+    if (!imageResource?.dataUrl) {
+      dispatch(
+        setImageUrl({
+          id: stampId,
+          data: {
+            isDownloading: true,
+          }
+        })
+      );
+      await getStampImageBlobFromStorageAsync(stampId)
+        .then(async (dataBlob) => {
+          if (dataBlob) {
+            const dataUrl = await convertToDataUrlFromBlob(dataBlob);
+
             dispatch(
               setImageUrl({
                 id: stampId,
-                data: url,
+                data: {
+                  isDownloading: false,
+                  dataUrl,
+                  dataSize: dataBlob.size
+                },
               })
             );
           }
         })
         .catch(() => {
-          console.error("ロードに失敗 stampId:", stampId);
+          console.error("画像のロードに失敗 stampId:", stampId);
+          dispatch(
+            setImageUrl({
+              id: stampId,
+              data: {
+                isDownloading: false,
+              },
+            })
+          );
         });
     }
   };
@@ -62,20 +105,48 @@ export const loadImageUrl = (stampId: string): ThunkResult<void> => {
 export const loadSoundUrl = (stampId: string): ThunkResult<void> => {
   return async (dispatch, getState) => {
     if (stampId == "") return;
-    if (!(stampId in getState().stampResources.soundUrls)) {
-      await getStampSoundURLFromStorageAsync(stampId)
-        .then((url) => {
-          if (url) {
+
+    const soundResource = getState().stampResources.soundResources[stampId];
+
+    // ダウンロード中の場合は弾く
+    if (soundResource && soundResource.isDownloading) return;
+
+    if (!soundResource?.dataUrl) {
+      dispatch(
+        setImageUrl({
+          id: stampId,
+          data: {
+            isDownloading: true,
+          }
+        })
+      );
+      await getStampSoundBlobFromStorageAsync(stampId)
+        .then(async (dataBlob) => {
+          if (dataBlob) {
+            const dataUrl = await convertToDataUrlFromBlob(dataBlob);
+
             dispatch(
               setSoundUrl({
                 id: stampId,
-                data: url,
+                data: {
+                  isDownloading: false,
+                  dataUrl,
+                  dataSize: dataBlob.size
+                }
               })
             );
           }
         })
         .catch(() => {
-          console.error("ロードに失敗 stampId:", stampId);
+          console.error("音声のロードに失敗 stampId:", stampId);
+          dispatch(
+            setSoundUrl({
+              id: stampId,
+              data: {
+                isDownloading: false
+              }
+            })
+          );
         });
     }
   };


### PR DESCRIPTION
## やったこと
- 画像をblobでローカルに保持するように設定

## やらなかったこと
- 画像取得失敗時の見た目は作ってないです

## レビュー項目
- [ ] スタンプ画像が取得できること
- [ ] 特に、ライブ画面でスタンプ画像が不要に取得されないこと

## 備考
- もうFireabse Cloud Storageが落ちないことを願ってこのPRを捧げます 🙏 
